### PR TITLE
add sessionInfo object to OTSession.js

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTSessionManager.java
+++ b/android/src/main/java/com/opentokreactnative/OTSessionManager.java
@@ -256,6 +256,16 @@ public class OTSessionManager extends ReactContextBaseJavaModule
         });
     }
 
+    @ReactMethod
+    public void getSessionInfo(Callback callback) {
+
+        Session mSession = sharedState.getSession();
+        WritableMap sessionInfo = Arguments.createMap();
+        sessionInfo.putString("sessionId", mSession.getSessionId());
+        sessionInfo.putMap("connection", prepareConnectionMap(mSession.getConnection()));
+        callback.invoke(sessionInfo);
+    }
+
     private boolean contains(ArrayList array, String value) {
 
         for (int i = 0; i < array.size(); i++) {

--- a/ios/OTSessionManager.m
+++ b/ios/OTSessionManager.m
@@ -50,5 +50,7 @@ RCT_EXTERN_METHOD(setJSComponentEvents:
                   (NSArray*)events)
 RCT_EXTERN_METHOD(removeJSComponentEvents:
                   (NSArray*)events)
+RCT_EXTERN_METHOD(getSessionInfo:
+                  (RCTResponseSenderBlock*)callback)
 @end
 

--- a/ios/OTSessionManager.swift
+++ b/ios/OTSessionManager.swift
@@ -172,6 +172,16 @@ class OTSessionManager: RCTEventEmitter {
       }
     }
   }
+
+  @objc func getSessionInfo(_ callback: RCTResponseSenderBlock) -> Void {
+    guard let session = OTRN.sharedState.session else { callback([NSNull()]); return }
+    var sessionInfo: Dictionary<String, Any> = [:];
+    if let connection = session.connection {
+      sessionInfo["connection"] = self.prepareJSConnectionEventData(connection);
+    }
+    sessionInfo["sessionId"] = session.sessionId;
+    callback([sessionInfo]);
+  }
   
   func sanitizeBooleanProperty(_ property: Any) -> Bool {
     guard let prop = property as? Bool else { return true; }

--- a/src/OTSession.js
+++ b/src/OTSession.js
@@ -11,6 +11,7 @@ export default class OTSession extends Component {
     super(props);
     this.state = {
       isConnected: false,
+      sessionInfo: null,
     };
   }
 
@@ -48,8 +49,11 @@ export default class OTSession extends Component {
       token: this.props.token,
     })
       .then(() => {
-        this.setState({
-          isConnected: true,
+        OT.getSessionInfo((sessionInfo) => {
+          this.setState({
+            isConnected: true,
+            sessionInfo,
+          });
         });
         const signalData = sanitizeSignalData(this.props.signal);
         OT.sendSignal(signalData, signalData.errorHandler);
@@ -63,14 +67,18 @@ export default class OTSession extends Component {
       .then(() => {
         this.setState({
           isConnected: false,
+          sessionInfo: null,
         });
       })
       .catch((error) => {
         handleError(error);
       });
   }
+  getSessionInfo() {
+    return this.state.sessionInfo;
+  }
   render() {
-    if (this.state.isConnected) {
+    if (this.state.isConnected && this.props.children) {
       const childrenWithProps = Children.map(
         this.props.children,
         child => (child ? cloneElement(
@@ -93,7 +101,7 @@ OTSession.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),
-  ]).isRequired,
+  ]),
   eventHandlers: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   signal: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };


### PR DESCRIPTION
* Adds sessionInfo object to OTSession 
``` 
sessionInfo: {
  sessionId: '',
  connection: {
    connectionId: '',
    creationTime: '',
  },
};
```

* Makes children optional for OTSession component b/c children should not be required when it's only used for signaling