### PR TITLE
add OTScreenCapturer.swift to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
   * `OTPublisherManager.swift`
   * `OTPublisherView.swift`
   * `OTRN.swift`
+  * `OTScreenCapturer.swift`
   * `OTSessionManager.m`
   * `OTSessionManager.swift`
   * `OTSubscriber.h`


### PR DESCRIPTION
Tiny change to the README—the build fails without OTScreenCapturer.swift included.