### PR TITLE
create a streamProperties prop for OTSubscriber so you can customize subscriber properties for each stream

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTSessionManager.java
+++ b/android/src/main/java/com/opentokreactnative/OTSessionManager.java
@@ -222,6 +222,22 @@ public class OTSessionManager extends ReactContextBaseJavaModule
     }
 
     @ReactMethod
+    public void subscribeToAudio(String streamId, Boolean subscribeToAudio) {
+
+        ConcurrentHashMap<String, Subscriber> mSubscribers = sharedState.getSubscribers();
+        Subscriber mSubscriber = mSubscribers.get(streamId);
+        mSubscriber.setSubscribeToAudio(subscribeToAudio);
+    }
+
+    @ReactMethod
+    public void subscribeToVideo(String streamId, Boolean subscribeToVideo) {
+
+        ConcurrentHashMap<String, Subscriber> mSubscribers = sharedState.getSubscribers();
+        Subscriber mSubscriber = mSubscribers.get(streamId);
+        mSubscriber.setSubscribeToVideo(subscribeToVideo);
+    }
+
+    @ReactMethod
     public void changeCameraPosition(String publisherId, String cameraPosition) {
 
         ConcurrentHashMap<String, Publisher> mPublishers = sharedState.getPublishers();

--- a/android/src/main/java/com/opentokreactnative/OTSessionManager.java
+++ b/android/src/main/java/com/opentokreactnative/OTSessionManager.java
@@ -226,7 +226,9 @@ public class OTSessionManager extends ReactContextBaseJavaModule
 
         ConcurrentHashMap<String, Subscriber> mSubscribers = sharedState.getSubscribers();
         Subscriber mSubscriber = mSubscribers.get(streamId);
-        mSubscriber.setSubscribeToAudio(subscribeToAudio);
+        if (mSubscriber != null) {
+            mSubscriber.setSubscribeToAudio(subscribeToAudio);
+        }
     }
 
     @ReactMethod
@@ -234,7 +236,9 @@ public class OTSessionManager extends ReactContextBaseJavaModule
 
         ConcurrentHashMap<String, Subscriber> mSubscribers = sharedState.getSubscribers();
         Subscriber mSubscriber = mSubscribers.get(streamId);
-        mSubscriber.setSubscribeToVideo(subscribeToVideo);
+        if (mSubscriber != null) {
+            mSubscriber.setSubscribeToVideo(subscribeToVideo);
+        }
     }
 
     @ReactMethod

--- a/docs/OTSubscriber.md
+++ b/docs/OTSubscriber.md
@@ -3,8 +3,9 @@
 | Prop | Type | Required | Description |
 | --- | --- | --- | --- |
 | sessionId | String | No | OpenTok Session Id. This is auto populated by wrapping `OTSubscriber` with `OTSession`
-| streamId | String| No | OpenTok Subscriber streamId. This is auto populated inside the `OTSubscriber` component when `streamCreated` event is fired from the native session delegate(iOS)/ interface(Android)
+| streamId | String| No | OpenTok Subscriber streamId. This is auto populated inside the `OTSubscriber` component when `streamCreated` event is fired from the native instance
 | properties | Object | No | Properties passed into the native subscriber instance
+| streamProperties | Object | No | Used to update individual subscriber instance properties
 | eventHandlers | Object&lt;Function&gt; | No | Event handlers passed into the native subscriber instance
 
 ## Properties 
@@ -37,3 +38,52 @@ The `OTSubscriber` component will subscribe to a specified stream from a specifi
   * **videoEnabled** (String) - This message is sent when the subscriber’s video stream starts (when there previously was no video) or resumes (after video was disabled). Check the reason parameter for the reason why the video started (or resumed).
   
   * **videoNetworkStats** (Object) — Sent periodically to report video statistics for the subscriber.
+
+  ```js
+class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      streamProperties: {},
+    };
+
+    this.subscriberProperties = {
+      subscribeToAudio: false,
+      subscribeToVideo: true,
+    };
+
+    this.sessionEventHandlers = {
+      streamCreated: event => {
+        const streamProperties = {...this.state.streamProperties, [event.streamId]: {
+          subscribeToAudio: true,
+          subscribeToVideo: false,
+          style: {
+            width: 400,
+            height: 300,
+          },
+        }};
+        this.setState({ streamProperties });
+      },
+    };
+
+    this.subscriberEventHandlers = {
+      error: (error) => {
+        console.log(`There was an error with the subscriber: ${error}`);
+      },
+    };
+  }
+
+  render() {
+    return (
+      <OTSession apiKey="your-api-key" sessionId="your-session-id" token="your-session-token" eventHandlers={this.sessionEventHandlers}>
+        <OTSubscriber
+          properties={this.subscriberProperties}
+          eventHandlers={this.subscriberEventHandlers}
+          style={{ height: 100, width: 100 }}
+          streamProperties={this.state.streamProperties}
+        />
+      </OTSession>
+    );
+  }
+}
+```

--- a/ios/OpenTokReactNative/OTSessionManager.m
+++ b/ios/OpenTokReactNative/OTSessionManager.m
@@ -41,6 +41,12 @@ RCT_EXTERN_METHOD(publishAudio:
 RCT_EXTERN_METHOD(publishVideo:
                   (NSString*)publisherId
                   pubVideo:(BOOL)pubVideo)
+RCT_EXTERN_METHOD(subscribeToAudio:
+                  (NSString*)streamId
+                  subAudio:(BOOL)subAudio)
+RCT_EXTERN_METHOD(subscribeToVideo:
+                  (NSString*)streamId
+                  subVideo:(BOOL)subVideo)
 RCT_EXTERN_METHOD(changeCameraPosition:
                   (NSString*)publisherId
                   cameraPosition:(NSString*)cameraPosition)

--- a/ios/OpenTokReactNative/OTSessionManager.swift
+++ b/ios/OpenTokReactNative/OTSessionManager.swift
@@ -142,6 +142,16 @@ class OTSessionManager: RCTEventEmitter {
     publisher.publishVideo = pubVideo;
   }
   
+  @objc func subscribeToAudio(_ streamId: String, subAudio: Bool) -> Void {
+    guard let subscriber = OTRN.sharedState.subscribers[streamId] else { return }
+    subscriber.subscribeToAudio = subAudio;
+  }
+    
+  @objc func subscribeToVideo(_ streamId: String, subVideo: Bool) -> Void {
+    guard let subscriber = OTRN.sharedState.subscribers[streamId] else { return }
+    subscriber.subscribeToVideo = subVideo;
+  }
+  
   @objc func changeCameraPosition(_ publisherId: String, cameraPosition: String) -> Void {
     guard let publisher = OTRN.sharedState.publishers[publisherId] else { return }
     publisher.cameraPosition = cameraPosition == "front" ? .front : .back;


### PR DESCRIPTION
This allows you to update `subscribeToAudio` and `subscribeToVideo` properties for the `OTSubscriber` component. 

However, this still does not allow you to have full control over which stream property to modify. We have two options:
 - Create `subscribeToAudio` and `subscribeToVideo` methods on the `OTSubscriber` component and expose them via `refs`. You would have to listen to the `streamCreated` events to get all of the stream IDs. After that, you can then modify these properties by feeding the `streamId` and value.
- Create a new API `OTStreams` that clones the `OTSubscriber` component and creates one for each stream. This would allow developers to wrap the sample `OTSubscriber` component in another component with it's own states and buttons modifying the subscriber properties as needed.

@sunweiyang @ASerga @emin93 @renanpupin @mbouxin @akandaurov @ythecombinator @rossenv @jonathanwmaddison What do you all think? 