### PR TITLE
Fixed typo video disabled event

### DIFF
--- a/ios/OpenTokReactNative/OTSessionManager.swift
+++ b/ios/OpenTokReactNative/OTSessionManager.swift
@@ -458,7 +458,7 @@ extension OTSessionManager: OTSubscriberKitNetworkStatsDelegate {
   }
   
   func subscriberVideoDisabled(_ subscriber: OTSubscriberKit, reason: OTSubscriberVideoEventReason) {
-    self.emitEvent("\(subscriberPreface)subscriberVideoEnabled", data: reason);
+    self.emitEvent("\(subscriberPreface)subscriberVideoDisabled", data: reason);
   }
   
   func subscriberVideoDisableWarning(_ subscriber: OTSubscriberKit) {


### PR DESCRIPTION
I applied your solution on the issue #109 @msach22 related to the `videoDisabled` event not fired and it works I already tested on iOS devices. 