### PR TITLE
Bug fix

### DIFF
--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -53,7 +53,7 @@ export default class OTSubscriber extends Component {
         handleError(error);
       } else {
         this.setState({
-          streams: [...this.state.streams, stream.streamId],
+          streams: [stream.streamId, ...this.state.streams],
         });
       }
     });

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -52,9 +52,15 @@ export default class OTSubscriber extends Component {
       if (error) {
         handleError(error);
       } else {
-        this.setState({
-          streams: [stream.streamId, ...this.state.streams],
-        });
+        if(stream.name === 'screen-share') {
+          this.setState({
+            streams: [stream.streamId, ...this.state.streams],
+          });
+        } else {
+          this.setState({
+            streams: [...this.state.streams, stream.streamId],
+          });
+        }  
       }
     });
   }
@@ -73,6 +79,7 @@ export default class OTSubscriber extends Component {
     });
   }
   render() {
+    console.log(JSON.stringify(this.state.streams));
     const childrenWithStreams = this.state.streams.map((streamId) => {
       const streamProperties = this.props.streamProperties[streamId];
       const style = isEmpty(streamProperties) ? this.props.style : (isUndefined(streamProperties.style) || isNull(streamProperties.style)) ? this.props.style : streamProperties.style;


### PR DESCRIPTION
After the initial stream is loaded, subsequent streams would not load
This fix orders stream subscriptions in the order which they were
created

<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x]  Added a descriptive commit message

### Solves issue(s)
https://github.com/opentok/opentok-react-native/issues/167
