### PR TITLE
surface view change

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTPublisherLayout.java
+++ b/android/src/main/java/com/opentokreactnative/OTPublisherLayout.java
@@ -32,7 +32,7 @@ public class OTPublisherLayout extends FrameLayout{
                 BaseVideoRenderer.STYLE_VIDEO_FILL);
         FrameLayout mPublisherViewContainer = new FrameLayout(getContext());
         if (mPublisher.getView() instanceof GLSurfaceView) {
-            ((GLSurfaceView) mPublisher.getView()).setZOrderOnTop(true);
+            ((GLSurfaceView) mPublisher.getView()).setZOrderMediaOverlay(false);
         }
         ConcurrentHashMap<String, FrameLayout> mPublisherViewContainers = sharedState.getPublisherViewContainers();
         mPublisherViewContainers.put(publisherId, mPublisherViewContainer);


### PR DESCRIPTION
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
Using the J-A-B-R sugestion: https://github.com/opentok/opentok-react-native/issues/162#issuecomment-423831565, use setZOrderMediaOverlay(false) instead setZOrderOnTop(true). Now, publisher can be overlapped by others components. Resolve the problem just in Publisher.

### Contributing checklist
- [OK] Code must follow existing styling conventions
- [OK ] Added a descriptive commit message

### Solves issue(s)
<!--- Mention the GitHub issues here -->

#162 #169
