### PR TITLE
[Android] Avoid app crash on receiving a signal from API

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTSessionManager.java
+++ b/android/src/main/java/com/opentokreactnative/OTSessionManager.java
@@ -612,7 +612,9 @@ public class OTSessionManager extends ReactContextBaseJavaModule
         WritableMap signalInfo = Arguments.createMap();
         signalInfo.putString("type", type);
         signalInfo.putString("data", data);
-        signalInfo.putString("connectionId", connection.getConnectionId());
+        if(connection != null) {
+            signalInfo.putString("connectionId", connection.getConnectionId());
+        }
         sendEventMap(this.getReactApplicationContext(), sessionPreface + "onSignalReceived", signalInfo);
         printLogs("onSignalReceived: Data: " + data + " Type: " + type);
     }


### PR DESCRIPTION
### Solves issue(s)
https://github.com/opentok/opentok-react-native/issues/220

*iOS*
iOS app also get a fatal error.
It's not enough to fix here https://github.com/opentok/opentok-react-native/blob/20eb060b0532e978dc395493563780115720ad0b/ios/OpenTokReactNative/OTSessionManager.swift#L379