### PR TITLE
Remove Canvas.MATRIX_SAVE_FLAG

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTScreenCapturer.java
+++ b/android/src/main/java/com/opentokreactnative/OTScreenCapturer.java
@@ -47,7 +47,7 @@ public class OTScreenCapturer extends BaseVideoCapturer {
                     canvas = new Canvas(bmp);
                     frame = new int[width * height];
                 }
-                canvas.save(Canvas.MATRIX_SAVE_FLAG);
+                canvas.save();
                 canvas.translate(-contentView.getScrollX(), - contentView.getScrollY());
                 contentView.draw(canvas);
 


### PR DESCRIPTION
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

### Solves issue(s)
[#197](https://github.com/opentok/opentok-react-native/issues/197)

Replace `canvas.save(Canvas.MATRIX_SAVE_FLAG)` by `canvas.save()` since the method save(int) was deprecated from [API 26](https://developer.android.com/sdk/api_diff/26/changes/android.graphics.Canvas), and removed from [API 28](https://developer.android.com/sdk/api_diff/28/changes/android.graphics.Canvas)
