### PR TITLE
Add containerStyle prop to OTSubscriber

### DIFF
--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -89,10 +89,12 @@ OTSubscriber.propTypes = {
   properties: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   eventHandlers: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   streamProperties: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  containerStyle: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 OTSubscriber.defaultProps = {
   properties: {},
   eventHandlers: {},
   streamProperties: {},
+  containerStyle: {},
 };

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -73,12 +73,13 @@ export default class OTSubscriber extends Component {
     });
   }
   render() {
+    const containerStyle = this.props.containerStyle;
     const childrenWithStreams = this.state.streams.map((streamId) => {
       const streamProperties = this.props.streamProperties[streamId];
       const style = isEmpty(streamProperties) ? this.props.style : (isUndefined(streamProperties.style) || isNull(streamProperties.style)) ? this.props.style : streamProperties.style;
       return <OTSubscriberView key={streamId} streamId={streamId} style={style} />
     });
-    return <View>{ childrenWithStreams }</View>;
+    return <View style={containerStyle}>{ childrenWithStreams }</View>;
   }
 }
 


### PR DESCRIPTION
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

This PR adds the `style` prop to the main `View` component that contains all the `OTSubscriberView` components. This way we could add styling to this View, for example:

```
<OTSubscriber
  containerStyle={styles.subscribersView}
/>

const styles = StyleSheet.create({
  subscribersView: {
    flex: 1,
    flexDirection: 'row',
    justifyContent: 'center',
    flexWrap: 'wrap',
    alignItems: 'flex-start' 
  }
})
```
Fixes: https://github.com/opentok/opentok-react-native/issues/227