### PR TITLE
Session Handlers sometimes were not cleared.

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTSessionManager.java
+++ b/android/src/main/java/com/opentokreactnative/OTSessionManager.java
@@ -222,6 +222,10 @@ public class OTSessionManager extends ReactContextBaseJavaModule
         disconnectCallback = callback;
         if (mSession != null) {
             mSession.disconnect();
+            if (connectionStatus == 0) {
+                disconnectCallback.invoke("Error disconnecting session. The session has already disconnected.");
+                disconnectCallback = null;
+            }
         }
         sharedState.setSession(null);
     }

--- a/src/OTSession.js
+++ b/src/OTSession.js
@@ -67,12 +67,11 @@ export default class OTSession extends Component {
   }
   disconnectSession() {
     OT.disconnectSession((disconnectError) => {
+      const events = sanitizeSessionEvents(this.props.eventHandlers);
+      removeNativeEvents(events);
       if (disconnectError) {
         handleError(disconnectError);
-      } else {
-        const events = sanitizeSessionEvents(this.props.eventHandlers);
-        removeNativeEvents(events);
-      }
+      } 
     });
   }
   getSessionInfo() {


### PR DESCRIPTION
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

### Solves issue(s)
<!--- Mention the GitHub issues here -->
No Issue

If a OTSession.disconnectSession() returns a disconnectError, all session handlers aren't cleared. And if  OT.disconnectSession() was called in Android and OTSesssionManager.onDisconnected(session) had been called before externally, it don't executes any callback.

This problem makes sometimes a call executes two ore more session handlers in different contexts.

![Captura de Tela 2019-04-10 às 17 31 59](https://user-images.githubusercontent.com/39625749/55959997-4cf17400-5c42-11e9-9822-b507bc220cc3.png)
Here we have one example. All Session handlers are calling twice in different contexts.
