### PR TITLE
Added framework search paths

### DIFF
--- a/ios/OpenTokReactNative.xcodeproj/project.pbxproj
+++ b/ios/OpenTokReactNative.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = Y6ZF2U3QJC;
+				FRAMEWORK_SEARCH_PATHS = "${SRCROOT}/../../../ios/Pods/OpenTok";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"${SRCROOT}/../../../ios/Pods/Headers/Public/**",
@@ -324,6 +325,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = Y6ZF2U3QJC;
+				FRAMEWORK_SEARCH_PATHS = "${SRCROOT}/../../../ios/Pods/OpenTok";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"${SRCROOT}/../../../ios/Pods/Headers/Public/**",


### PR DESCRIPTION
Fixes building error

```
info .../app/node_modules/opentok-react-native/ios/OpenTokReactNative/OpenTokReactNative-Bridging-Header.h:8:9: error: 'OpenTok/OpenTok.h' file not found
#import <OpenTok/OpenTok.h>
        ^
1 error generated.
<unknown>:0: error: failed to emit precompiled header '.../app/ios/build/yourcoach/Build/Intermediates.noindex/PrecompiledHeaders/OpenTokReactNative-Bridging-Header-swift_315LNEK3FUC01-clang_ECUMBBKFI663.pch' for bridging header '.../app/node_modules/opentok-react-native/ios/OpenTokReactNative/OpenTokReactNative-Bridging-Header.h'
```