### PR TITLE
Add videoType to RN stream map

### DIFF
--- a/android/src/main/java/com/opentokreactnative/utils/EventUtils.java
+++ b/android/src/main/java/com/opentokreactnative/utils/EventUtils.java
@@ -34,6 +34,11 @@ public final class EventUtils {
             streamInfo.putString("name", stream.getName());
             streamInfo.putBoolean("hasAudio", stream.hasAudio());
             streamInfo.putBoolean("hasVideo", stream.hasVideo());
+            if (stream.getStreamVideoType().equals(Stream.StreamVideoType.StreamVideoTypeScreen)) {
+                streamInfo.putString("videoType", "screen");
+            } else {
+                streamInfo.putString("videoType", "camera");
+            }
         }
         return streamInfo;
     }

--- a/ios/OpenTokReactNative/Utils/EventUtils.swift
+++ b/ios/OpenTokReactNative/Utils/EventUtils.swift
@@ -35,6 +35,7 @@ class EventUtils {
         streamInfo["creationTime"] = convertDateToString(stream.creationTime);
         streamInfo["height"] = stream.videoDimensions.height;
         streamInfo["width"] = stream.videoDimensions.width;
+        streamInfo["videoType"] = stream.videoType == OTStreamVideoType.screen ? "screen" : "camera"
         return streamInfo;
     }
     


### PR DESCRIPTION
Currently, the event streamCreated is returning a stream map with several properties such us `streamId`, `connectionId`, `hasAudio`, `hasVideo`, etc. But there is no property for the videoType.

This PR adds the property `videoType` in the react native stream map with two possible values: `camera` or `screen`.

