### PR TITLE
Add publisher streamId in the subscriberStreams data structure

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTSessionManager.java
+++ b/android/src/main/java/com/opentokreactnative/OTSessionManager.java
@@ -558,6 +558,8 @@ public class OTSessionManager extends ReactContextBaseJavaModule
     public void onStreamCreated(PublisherKit publisherKit, Stream stream) {
 
         String publisherId = Utils.getPublisherId(publisherKit);
+        ConcurrentHashMap<String, Stream> mSubscriberStreams = sharedState.getSubscriberStreams();
+        mSubscriberStreams.put(stream.getStreamId(), stream);
         if (publisherId.length() > 0) {
             String event = publisherId + ":" + publisherPreface + "onStreamCreated";;
             WritableMap streamInfo = EventUtils.prepareJSStreamMap(stream);
@@ -572,6 +574,9 @@ public class OTSessionManager extends ReactContextBaseJavaModule
 
         String publisherId = Utils.getPublisherId(publisherKit);
         String event = publisherId + ":" + publisherPreface + "onStreamDestroyed";
+        ConcurrentHashMap<String, Stream> mSubscriberStreams = sharedState.getSubscriberStreams();
+        String mStreamId = stream.getStreamId();
+        mSubscriberStreams.remove(mStreamId);
         if (publisherId.length() > 0) {
             WritableMap streamInfo = EventUtils.prepareJSStreamMap(stream);
             sendEventMap(this.getReactApplicationContext(), event, streamInfo);

--- a/docs/OTSubscriber.md
+++ b/docs/OTSubscriber.md
@@ -7,6 +7,7 @@
 | properties | Object | No | Properties passed into the native subscriber instance
 | streamProperties | Object | No | Used to update individual subscriber instance properties
 | eventHandlers | Object&lt;Function&gt; | No | Event handlers passed into the native subscriber instance
+| subscribeToSelf | Boolean | No | If true, subscribe to his own stream (default: false)
 
 ## Properties 
   * **subscribeToAudio** (Boolean) — Whether to subscribe to audio.

--- a/ios/OpenTokReactNative/OTSessionManager.swift
+++ b/ios/OpenTokReactNative/OTSessionManager.swift
@@ -411,6 +411,7 @@ extension OTSessionManager: OTSessionDelegate {
 extension OTSessionManager: OTPublisherDelegate {
     func publisher(_ publisher: OTPublisherKit, streamCreated stream: OTStream) {
         OTRN.sharedState.publisherStreams.updateValue(stream, forKey: stream.streamId)
+        OTRN.sharedState.subscriberStreams.updateValue(stream, forKey: stream.streamId)
         let publisherId = Utils.getPublisherId(publisher as! OTPublisher);
         if (publisherId.count > 0) {
             OTRN.sharedState.isPublishing[publisherId] = true;
@@ -424,6 +425,7 @@ extension OTSessionManager: OTPublisherDelegate {
     func publisher(_ publisher: OTPublisherKit, streamDestroyed stream: OTStream) {
         OTRN.sharedState.streamObservers.removeValue(forKey: stream.streamId)
         OTRN.sharedState.publisherStreams.removeValue(forKey: stream.streamId)
+        OTRN.sharedState.subscriberStreams.removeValue(forKey: stream.streamId)
         let publisherId = Utils.getPublisherId(publisher as! OTPublisher);
         OTRN.sharedState.isPublishing[publisherId] = false;
         if (publisherId.count > 0) {

--- a/src/OTSession.js
+++ b/src/OTSession.js
@@ -97,6 +97,7 @@ export default class OTSession extends Component {
           child,
           {
             sessionId: this.props.sessionId,
+            sessionInfo: this.state.sessionInfo
           },
         ) : child),
       );

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -98,6 +98,7 @@ OTSubscriber.propTypes = {
   streamProperties: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   containerStyle: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   sessionInfo: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  subscribeToSelf: PropTypes.bool
 };
 
 OTSubscriber.defaultProps = {
@@ -105,5 +106,6 @@ OTSubscriber.defaultProps = {
   eventHandlers: {},
   streamProperties: {},
   containerStyle: {},
-  sessionInfo: {}
+  sessionInfo: {},
+  subscribeToSelf: false
 };

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -52,8 +52,8 @@ export default class OTSubscriber extends Component {
     const subscriberProperties = isNull(streamProperties[stream.streamId]) ?
                                   sanitizeProperties(properties) : sanitizeProperties(streamProperties[stream.streamId]);
     // Subscribe to streams. If subscribeToSelf is true, subscribe also to his own stream
-    if ((subscribeToSelf && sessionInfo && sessionInfo.connection && sessionInfo.connection.connectionId === stream.connectionId ) ||
-    (sessionInfo && sessionInfo.connection && sessionInfo.connection.connectionId !== stream.connectionId) ){
+    const sessionInfoConnectionId = sessionInfo && sessionInfo.connection ? sessionInfo.connection.connectionId : null;
+    if (subscribeToSelf || (sessionInfoConnectionId !== stream.connectionId) ){
         OT.subscribeToStream(stream.streamId, subscriberProperties, (error) => {
             if (error) {
                 this.otrnEventHandler(error);

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -53,7 +53,7 @@ export default class OTSubscriber extends Component {
                                   sanitizeProperties(properties) : sanitizeProperties(streamProperties[stream.streamId]);
     // Subscribe to streams. If subscribeToSelf is true, subscribe also to his own stream
     const sessionInfoConnectionId = sessionInfo && sessionInfo.connection ? sessionInfo.connection.connectionId : null;
-    if (subscribeToSelf || (sessionInfoConnectionId !== stream.connectionId) ){
+    if (subscribeToSelf || (sessionInfoConnectionId !== stream.connectionId)){
         OT.subscribeToStream(stream.streamId, subscriberProperties, (error) => {
             if (error) {
                 this.otrnEventHandler(error);


### PR DESCRIPTION
Hello,

I modified the **OTSessionManager** both in `ios` and `android` folders to add the publisher stream to the subscriber stream data structure (`mSubscriberStreams`  for Android and `OTRN.sharedState.subscriberStreams` for iOS).

This change allows you to subscribe to your own stream. I need this to simulate a NetworkTest.
The Network Test will follow these steps:

1. Connect to a session
2. Publish a stream
3. Subscribe to his own stream
4. Run stats using the OTSubscriber events such as `audioNetworkStats` and `videoNetworkStats`
5. Disconnects


