### PR TITLE
- Fix Issue#286

### DIFF
--- a/ios/OpenTokReactNative/OTSessionManager.swift
+++ b/ios/OpenTokReactNative/OTSessionManager.swift
@@ -433,7 +433,8 @@ extension OTSessionManager: OTPublisherDelegate {
             let streamInfo: Dictionary<String, Any> = EventUtils.prepareJSStreamEventData(stream);
             self.emitEvent("\(publisherId):\(EventUtils.publisherPreface)streamDestroyed", data: streamInfo);
         }
-        OTRN.sharedState.publishers[publisherId] = nil;
+        // No need to create new publisher 
+        // OTRN.sharedState.publishers[publisherId] = nil;
         OTRN.sharedState.isPublishing[publisherId] = nil;
         guard let callback = OTRN.sharedState.publisherDestroyedCallbacks[publisherId] else {
             printLogs("OTRN: Publisher Stream destroyed")


### PR DESCRIPTION
- ios/OTSessionManager.swift: streamDestroyed no need to create new publisher between sessions

No need to create a new publisher each time a new session is created.
 
However, this is also a bug in the iOS SDK `2.16.1` because it should work also if you create new instances each time. 

### Solves issue(s)
Solves:  #286 
