### PR TITLE
Allowed children to be passed to OTSubscriber for custom rendering of streams

### DIFF
--- a/docs/OTSubscriber.md
+++ b/docs/OTSubscriber.md
@@ -10,7 +10,7 @@
 | subscribeToSelf | Boolean | No | If set to true, the subscriber can subscribe to it's own publisher stream (default: false)
 | children | Function | No | A render prop allowing individual rendering of each `OTSubscriberView`
 
-## Properties 
+## Properties
   * **subscribeToAudio** (Boolean) — Whether to subscribe to audio.
 
   * **subscribeToVideo** (Boolean) — Whether to subscribe video.
@@ -26,13 +26,13 @@ The `OTSubscriber` component will subscribe to a specified stream from a specifi
   * **connected** () — Sent when the subscriber successfully connects to the stream.
 
   * **disconnected** () — Called when the subscriber’s stream has been interrupted.
-  
+
   * **error** (Object) — Sent if the subscriber fails to connect to its stream.
 
   * **otrnError** (Object) — Sent if there is an error with the communication between the native subscriber instance and the JS component.
 
   * **videoDataReceived** () - Sent when a frame of video has been decoded. Although the subscriber will connect in a relatively short time, video can take more time to synchronize. This message is sent after the `connected` message is sent.
-  
+
   * **videoDisabled** (String) — This message is sent when the subscriber stops receiving video. Check the reason parameter for the reason why the video stopped.
 
   * **videoDisableWarning** () - This message is sent when the OpenTok Media Router determines that the stream quality has degraded and the video will be disabled if the quality degrades further. If the quality degrades further, the subscriber disables the video and the `videoDisabled` message is sent. If the stream quality improves, the `videoDisableWarningLifted` message is sent.
@@ -40,7 +40,7 @@ The `OTSubscriber` component will subscribe to a specified stream from a specifi
   * **videoDisableWarningLifted** () — This message is sent when the subscriber’s video stream starts (when there previously was no video) or resumes (after video was disabled). Check the reason parameter for the reason why the video started (or resumed).
 
   * **videoEnabled** (String) - This message is sent when the subscriber’s video stream starts (when there previously was no video) or resumes (after video was disabled). Check the reason parameter for the reason why the video started (or resumed).
-  
+
   * **videoNetworkStats** (Object) — Sent periodically to report video statistics for the subscriber.
 
   ```js
@@ -96,11 +96,12 @@ class App extends Component {
 
 It's possible to manually render streams, i.e. to allow touch interaction or provide individual styling for each `OTSubscriberView`.
 
-By using children as a render prop function, we can take care of rendering each `OTSubscriberView` individually, i.e.: 
+By using children as a render prop function, we can take care of rendering each `OTSubscriberView` individually, i.e.:
 
 ```js
 <OTSubscriber
-	streamProperties={streamProperties}>
+  streamProperties={streamProperties}
+  >
     {this.renderSubscribers}
 </OTSubscriber>
 ```
@@ -115,7 +116,7 @@ renderSubscribers = (subscribers) => {
       key={streamId}
       style={subscriberWrapperStyle}
     >
-	  <OTSubscriberView streamId={streamId} style={subscriberStyle} />
+    <OTSubscriberView streamId={streamId} style={subscriberStyle} />
     </TouchableOpacity>
   ))}
 }

--- a/docs/OTSubscriber.md
+++ b/docs/OTSubscriber.md
@@ -8,6 +8,7 @@
 | streamProperties | Object | No | Used to update individual subscriber instance properties
 | eventHandlers | Object&lt;Function&gt; | No | Event handlers passed into the native subscriber instance
 | subscribeToSelf | Boolean | No | If set to true, the subscriber can subscribe to it's own publisher stream (default: false)
+| children | Function | No | A render prop allowing individual rendering of each `OTSubscriberView`
 
 ## Properties 
   * **subscribeToAudio** (Boolean) — Whether to subscribe to audio.
@@ -88,5 +89,34 @@ class App extends Component {
       </OTSession>
     );
   }
+}
+```
+
+## Manual rendering of streams
+
+It's possible to manually render streams, i.e. to allow touch interaction or provide individual styling for each `OTSubscriberView`.
+
+By using children as a render prop function, we can take care of rendering each `OTSubscriberView` individually, i.e.: 
+
+```js
+<OTSubscriber
+	streamProperties={streamProperties}>
+    {this.renderSubscribers}
+</OTSubscriber>
+```
+
+The render prop function could be written as follows:
+
+```js
+renderSubscribers = (subscribers) => {
+  {subscribers.map(streamId => (
+    <TouchableOpacity
+      onPress={() => this.handleStreamPress(streamId)}
+      key={streamId}
+      style={subscriberWrapperStyle}
+    >
+	  <OTSubscriberView streamId={streamId} style={subscriberStyle} />
+    </TouchableOpacity>
+  ))}
 }
 ```

--- a/docs/OTSubscriber.md
+++ b/docs/OTSubscriber.md
@@ -116,7 +116,7 @@ renderSubscribers = (subscribers) => {
       key={streamId}
       style={subscriberWrapperStyle}
     >
-    <OTSubscriberView streamId={streamId} style={subscriberStyle} />
+      <OTSubscriberView streamId={streamId} style={subscriberStyle} />
     </TouchableOpacity>
   ))}
 }

--- a/docs/OTSubscriber.md
+++ b/docs/OTSubscriber.md
@@ -8,7 +8,7 @@
 | streamProperties | Object | No | Used to update individual subscriber instance properties
 | eventHandlers | Object&lt;Function&gt; | No | Event handlers passed into the native subscriber instance
 | subscribeToSelf | Boolean | No | If set to true, the subscriber can subscribe to it's own publisher stream (default: false)
-| children | Function | No | A render prop allowing individual rendering of each `OTSubscriberView`
+| children | Function | No | A render prop allowing individual rendering of each stream
 
 ## Properties
   * **subscribeToAudio** (Boolean) — Whether to subscribe to audio.
@@ -92,25 +92,26 @@ class App extends Component {
 }
 ```
 
-## Manual rendering of streams
+## Custom rendering of streams
 
-It's possible to manually render streams, i.e. to allow touch interaction or provide individual styling for each `OTSubscriberView`.
+`OTSubscriber` accepts a render prop function that enables custom rendering of individual streams, e.g. to allow touch interaction or provide individual styling for each `OTSubscriberView`.
+An array of stream IDs is passed to the render prop function as its only argument.
 
-By using children as a render prop function, we can take care of rendering each `OTSubscriberView` individually, i.e.:
+For example, to display the stream, pass its ID as `streamId` prop to the `OTSubscriberView` component:
 
 ```js
-<OTSubscriber
-  streamProperties={streamProperties}
-  >
-    {this.renderSubscribers}
+import { OTSubscriberView } from 'opentok-react-native'
+
+// Render method
+
+<OTSubscriber>
+  {this.renderSubscribers}
 </OTSubscriber>
-```
 
-The render prop function could be written as follows:
+// Render prop function
 
-```js
 renderSubscribers = (subscribers) => {
-  {subscribers.map(streamId => (
+  return subscribers.map((streamId) => (
     <TouchableOpacity
       onPress={() => this.handleStreamPress(streamId)}
       key={streamId}
@@ -118,6 +119,11 @@ renderSubscribers = (subscribers) => {
     >
       <OTSubscriberView streamId={streamId} style={subscriberStyle} />
     </TouchableOpacity>
-  ))}
-}
+  ));
+};
 ```
+
+Note: `streamProperties` prop is ignored if a children prop is passed.
+
+
+

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -96,7 +96,7 @@ export default class OTSubscriber extends Component {
 const viewPropTypes = View.propTypes;
 OTSubscriber.propTypes = {
   ...viewPropTypes,
-  children: React.PropTypes.func,
+  children: PropTypes.func,
   properties: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   eventHandlers: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   streamProperties: PropTypes.object, // eslint-disable-line react/forbid-prop-types

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -80,8 +80,8 @@ export default class OTSubscriber extends Component {
     });
   }
   render() {
-    const containerStyle = this.props.containerStyle;
     if (!this.props.children) {
+      const containerStyle = this.props.containerStyle;
       const childrenWithStreams = this.state.streams.map((streamId) => {
         const streamProperties = this.props.streamProperties[streamId];
         const style = isEmpty(streamProperties) ? this.props.style : (isUndefined(streamProperties.style) || isNull(streamProperties.style)) ? this.props.style : streamProperties.style;
@@ -89,7 +89,7 @@ export default class OTSubscriber extends Component {
       });
       return <View style={containerStyle}>{ childrenWithStreams }</View>;
     }
-    return this.props.children(this.state.streams);
+    return this.props.children(this.state.streams) || null;
   }
 }
 

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -19,7 +19,7 @@ export default class OTSubscriber extends Component {
       streamCreated: Platform.OS === 'android' ? 'session:onStreamReceived' : 'session:streamCreated',
     };
     this.componentEventsArray = Object.values(this.componentEvents);
-    this.otrnEventHandler = getOtrnErrorEventHandler(this.props.eventHandlers); 
+    this.otrnEventHandler = getOtrnErrorEventHandler(this.props.eventHandlers);
   }
   componentWillMount() {
     this.streamCreated = nativeEvents.addListener(this.componentEvents.streamCreated, stream => this.streamCreatedHandler(stream));
@@ -47,7 +47,7 @@ export default class OTSubscriber extends Component {
     removeNativeEvents(events);
   }
   streamCreatedHandler = (stream) => {
-    const { subscribeToSelf } = this.state;  
+    const { subscribeToSelf } = this.state;
     const { streamProperties, properties, sessionInfo } = this.props;
     const subscriberProperties = isNull(streamProperties[stream.streamId]) ?
                                   sanitizeProperties(properties) : sanitizeProperties(streamProperties[stream.streamId]);
@@ -63,7 +63,7 @@ export default class OTSubscriber extends Component {
                 });
             }
             });
-        }                             
+        }
   }
   streamDestroyedHandler = (stream) => {
     OT.removeSubscriber(stream.streamId, (error) => {
@@ -81,18 +81,22 @@ export default class OTSubscriber extends Component {
   }
   render() {
     const containerStyle = this.props.containerStyle;
-    const childrenWithStreams = this.state.streams.map((streamId) => {
-      const streamProperties = this.props.streamProperties[streamId];
-      const style = isEmpty(streamProperties) ? this.props.style : (isUndefined(streamProperties.style) || isNull(streamProperties.style)) ? this.props.style : streamProperties.style;
-      return <OTSubscriberView key={streamId} streamId={streamId} style={style} />
-    });
-    return <View style={containerStyle}>{ childrenWithStreams }</View>;
+    if (!this.props.children) {
+      const childrenWithStreams = this.state.streams.map((streamId) => {
+        const streamProperties = this.props.streamProperties[streamId];
+        const style = isEmpty(streamProperties) ? this.props.style : (isUndefined(streamProperties.style) || isNull(streamProperties.style)) ? this.props.style : streamProperties.style;
+        return <OTSubscriberView key={streamId} streamId={streamId} style={style} />
+      });
+      return <View style={containerStyle}>{ childrenWithStreams }</View>;
+    }
+    return this.props.children(this.state.streams);
   }
 }
 
 const viewPropTypes = View.propTypes;
 OTSubscriber.propTypes = {
   ...viewPropTypes,
+  children: React.PropTypes.func,
   properties: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   eventHandlers: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   streamProperties: PropTypes.object, // eslint-disable-line react/forbid-prop-types

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,13 @@
 import OTSession from './OTSession';
 import OTPublisher from './OTPublisher';
 import OTSubscriber from './OTSubscriber';
+import OTSubscriberView from './views/OTSubscriberView';
 import { OT } from './OT';
 
-export { 
+export {
   OTSession,
   OTPublisher,
   OTSubscriber,
+  OTSubscriberView,
   OT,
 };


### PR DESCRIPTION
Here's a small PR to allow custom rendering of streams via render props, that adheres to #289 proposal and it's backwards compatible.
It would also allow to wrap `OTSubscriberView` with a `View` to be able to use `borderRadius`, adressing #174.

An example of use:

```javascript
      <OTSubscriber
        streamProperties={streamProperties}>
        {this.renderSubscribers}
      </OTSubscriber>

      ...

      renderSubscribers = (subscribers) => {
          {subscribers.map((streamId) => (
            <TouchableOpacity
              onPress={() => this.handleStreamPress(streamId)}
              key={streamId}
              style={subscriberStyle}
            >
              <OTSubscriberView streamId={streamId} style={subscriberStyle} />
            </TouchableOpacity>
          ))}
      }

```