### PR TITLE
Fix `Attempted to register RCTBridgeModule class OTSessionManager` issue after opening/reloading app

### DIFF
--- a/ios/OpenTokReactNative.xcodeproj/project.pbxproj
+++ b/ios/OpenTokReactNative.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		9C6F95B920ACE8BE00FEAD68 /* OpenTokReactNative.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C6F95B820ACE8BE00FEAD68 /* OpenTokReactNative.m */; };
 		9C6F95BA20ACE8BE00FEAD68 /* OpenTokReactNative.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9C6F95B720ACE8BE00FEAD68 /* OpenTokReactNative.h */; };
-		9C6F95CD20ACE90E00FEAD68 /* OTSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C6F95C120ACE90D00FEAD68 /* OTSessionManager.m */; };
 		9C6F95CE20ACE90E00FEAD68 /* OTSubscriberManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C6F95C220ACE90D00FEAD68 /* OTSubscriberManager.swift */; };
 		9C6F95CF20ACE90E00FEAD68 /* OTPublisherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C6F95C320ACE90E00FEAD68 /* OTPublisherView.swift */; };
 		9C6F95D020ACE90E00FEAD68 /* OTSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C6F95C420ACE90E00FEAD68 /* OTSubscriber.m */; };
@@ -20,7 +19,7 @@
 		9C6F95D620ACE90E00FEAD68 /* OTPublisher.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C6F95CC20ACE90E00FEAD68 /* OTPublisher.m */; };
 		9C86849D218E2B5A004679BA /* EventUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C86849C218E2B5A004679BA /* EventUtils.swift */; };
 		9C86850F218E3433004679BA /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C86850E218E3433004679BA /* Utils.swift */; };
-		DED80B3522DFB01F0094CDC9 /* TBScreenCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = DED80B3322DFB01F0094CDC9 /* TBScreenCapture.m */; };
+		BA0CCEB72313FD6200F3C9ED /* OTSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C6F95C120ACE90D00FEAD68 /* OTSessionManager.m */; };
 		DED80B3822DFB02F0094CDC9 /* OTScreenCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = DED80B3622DFB02E0094CDC9 /* OTScreenCapture.m */; };
 /* End PBXBuildFile section */
 
@@ -181,15 +180,14 @@
 				9C6F95D120ACE90E00FEAD68 /* OTPublisherManager.swift in Sources */,
 				9C86849D218E2B5A004679BA /* EventUtils.swift in Sources */,
 				9C6F95D220ACE90E00FEAD68 /* OTSessionManager.swift in Sources */,
+				BA0CCEB72313FD6200F3C9ED /* OTSessionManager.m in Sources */,
 				9C6F95D320ACE90E00FEAD68 /* OTSubscriberView.swift in Sources */,
 				9C86850F218E3433004679BA /* Utils.swift in Sources */,
 				9C6F95CF20ACE90E00FEAD68 /* OTPublisherView.swift in Sources */,
 				9C6F95CE20ACE90E00FEAD68 /* OTSubscriberManager.swift in Sources */,
 				9C6F95B920ACE8BE00FEAD68 /* OpenTokReactNative.m in Sources */,
-				9C6F95CD20ACE90E00FEAD68 /* OTSessionManager.m in Sources */,
 				9C6F95D620ACE90E00FEAD68 /* OTPublisher.m in Sources */,
 				9C6F95D520ACE90E00FEAD68 /* OTRN.swift in Sources */,
-				9C6F95CD20ACE90E00FEAD68 /* OTSessionManager.m in Sources */,
 				DED80B3822DFB02F0094CDC9 /* OTScreenCapture.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

### Solves issue(s)
Fix `Attempted to register RCTBridgeModule class OTSessionManager` issue after opening/reloading app because of adding `OTSessionManager.m` file to "Compile sources" twice 
<img width="358" alt="Screen Shot 2019-08-25 at 8 51 12 PM" src="https://user-images.githubusercontent.com/33656379/63691709-9967d580-c818-11e9-8ffc-e7094de6ad24.png">