### PR TITLE
Fix reload in iOS

### DIFF
--- a/ios/OpenTokReactNative/OTSessionManager.swift
+++ b/ios/OpenTokReactNative/OTSessionManager.swift
@@ -305,8 +305,8 @@ class OTSessionManager: RCTEventEmitter {
     }
     
     func emitEvent(_ event: String, data: Any) -> Void {
-        if (self.jsEvents.contains(event) || self.componentEvents.contains(event)) {
-            self.sendEvent(withName: event, body: data);
+        if (self.bridge != nil && (self.jsEvents.contains(event) || self.componentEvents.contains(event))) {
+           self.sendEvent(withName: event, body: data);
         }
     }
     


### PR DESCRIPTION
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

Currently, when reloading the app in iOS the app can crash with the following error:
```
Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Error when sending event: 489ddd75-d522-43ff-99f7-44dec277e071:publisher:audioLevelUpdated with body: 0.0030518509447574615. Bridge is not set. This is probably because you've explicitly synthesized the bridge in OTSessionManager, even though it's inherited from RCTEventEmitter.'
```
This PR validates if the Bridge is set before emitting an event.

