### PR TITLE
Prevent to unpublish on disconnected sessions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:${_reactNativeVersion}"  // From node_modules
-    implementation 'com.opentok.android:opentok-android-sdk:2.16.1'
+    implementation 'com.opentok.android:opentok-android-sdk:2.16.2'
 }

--- a/ios/OpenTokReactNative/OTSessionManager.swift
+++ b/ios/OpenTokReactNative/OTSessionManager.swift
@@ -252,18 +252,15 @@ class OTSessionManager: RCTEventEmitter {
             var error: OTError?
             if let isPublishing = OTRN.sharedState.isPublishing[publisherId] {
                 if (isPublishing) {
-                    guard let sessionId = publisher.session?.sessionId else {
-                        let errorInfo = EventUtils.createErrorMessage("Error destroying publisher. Could not find sessionId")
-                        callback([errorInfo]);
-                        return
-                    }
-                    guard let session = OTRN.sharedState.sessions[sessionId] else {
-                        let errorInfo = EventUtils.createErrorMessage("Error destroying publisher. Could not find native session instance")
-                        callback([errorInfo]);
-                        return
-                    }
-                    if (session.sessionConnectionStatus.rawValue == 1) {
-                        session.unpublish(publisher, error: &error)
+                    if let sessionId = publisher.session?.sessionId {
+                        guard let session = OTRN.sharedState.sessions[sessionId] else {
+                            let errorInfo = EventUtils.createErrorMessage("Error destroying publisher. Could not find native session instance")
+                            callback([errorInfo]);
+                            return
+                        }
+                        if (session.sessionConnectionStatus.rawValue == 1) {
+                            session.unpublish(publisher, error: &error)
+                        }
                     }
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-react-native",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "opentok-react-native",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "React Native components for OpenTok iOS and Android SDKs",
   "main": "src/index.js",
-  "homepage": "www.tokbox.com",
+  "homepage": "https://www.tokbox.com",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

In this PR we're validating whether the session is empty before unpublishing.
Additionally we're updating the version of OpenTok Android SDK to 2.16.2

### Solves issue(s)
#337 

