### PR TITLE
Bump opentalk-android-sdk from 2.16.5 to 2.17.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:${_reactNativeVersion}"  // From node_modules
-    implementation 'com.opentok.android:opentok-android-sdk:2.16.5'
+    implementation 'com.opentok.android:opentok-android-sdk:2.17.0'
 }


### PR DESCRIPTION
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->


### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

### Solves issue(s)
<!--- Mention the GitHub issues here -->
Bumps the Opentalk Android SDK to version 2.17.0 to fix issue https://github.com/opentok/opentok-react-native/issues/410
