### PR TITLE
fix: incorrect audio bitrate sanitization

### DIFF
--- a/src/helpers/OTPublisherHelper.js
+++ b/src/helpers/OTPublisherHelper.js
@@ -31,7 +31,7 @@ const sanitizeCameraPosition = (cameraPosition = 'front') => (cameraPosition ===
 const sanitizeVideoSource = (videoSource = 'camera') => (videoSource === 'camera' ? 'camera' : 'screen');
 
 const sanitizeAudioBitrate = (audioBitrate = 40000) =>
-  (audioBitrate < 80000 || audioBitrate > 128000 ? 40000 : audioBitrate);
+  (audioBitrate < 6000 || audioBitrate > 510000 ? 40000 : audioBitrate);
 
 const sanitizeProperties = (properties) => {
   if (typeof properties !== 'object') {

--- a/src/helpers/OTPublisherHelper.js
+++ b/src/helpers/OTPublisherHelper.js
@@ -1,4 +1,4 @@
-import { sanitizeBooleanProperty, reassignEvents } from './OTHelper'
+import { sanitizeBooleanProperty, reassignEvents } from './OTHelper';
 
 const sanitizeResolution = (resolution) => {
   switch (resolution) {

--- a/src/helpers/OTPublisherHelper.js
+++ b/src/helpers/OTPublisherHelper.js
@@ -1,4 +1,4 @@
-import { sanitizeBooleanProperty, reassignEvents } from './OTHelper';
+import { sanitizeBooleanProperty, reassignEvents } from './OTHelper'
 
 const sanitizeResolution = (resolution) => {
   switch (resolution) {


### PR DESCRIPTION
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

### Solves issue(s)
The [OpenTok docs](https://tokbox.com/developer/sdks/ios/reference/Classes/OTPublisherKitSettings.html#//api/name/audioBitrate) mention that the supported audio bitrate ranges from 6k to 510k (the docs of this library as well). However, the sanitization method didn't allow values < 80k or > 128k (apart from the fallback default of 40k).