### PR TITLE
fix: audio crash on teardown

### DIFF
--- a/ios/OpenTokReactNative/OTCustomAudioDriver.swift
+++ b/ios/OpenTokReactNative/OTCustomAudioDriver.swift
@@ -662,7 +662,7 @@ func updatePlayoutDelay(withAudioDevice audioDevice: OTCustomAudioDriver) {
         // HW output latency
         let interval = session.outputLatency
         audioDevice.playoutDelay += UInt32(interval * 1000000)
-        // HW buffer duration 
+        // HW buffer duration
         let ioInterval = session.ioBufferDuration
         audioDevice.playoutDelay += UInt32(ioInterval * 1000000)
         audioDevice.playoutDelay += UInt32(audioDevice.playoutAudioUnitPropertyLatency * 1000000)

--- a/ios/OpenTokReactNative/OTCustomAudioDriver.swift
+++ b/ios/OpenTokReactNative/OTCustomAudioDriver.swift
@@ -662,7 +662,7 @@ func updatePlayoutDelay(withAudioDevice audioDevice: OTCustomAudioDriver) {
         // HW output latency
         let interval = session.outputLatency
         audioDevice.playoutDelay += UInt32(interval * 1000000)
-        // HW buffer duration
+        // HW buffer duration 
         let ioInterval = session.ioBufferDuration
         audioDevice.playoutDelay += UInt32(ioInterval * 1000000)
         audioDevice.playoutDelay += UInt32(audioDevice.playoutAudioUnitPropertyLatency * 1000000)

--- a/ios/OpenTokReactNative/OTCustomAudioDriver.swift
+++ b/ios/OpenTokReactNative/OTCustomAudioDriver.swift
@@ -354,10 +354,12 @@ extension OTCustomAudioDriver: OTAudioDevice {
         
         playing = false
         
-        let result = AudioOutputUnitStop(playoutVoiceUnit!)
-        if result != noErr {
-            print("Error creaing playout unit")
-            return false
+        if playoutVoiceUnit != nil {
+            let result = AudioOutputUnitStop(playoutVoiceUnit!)
+            if result != noErr {
+                print("Error creaing playout unit")
+                return false
+            }
         }
         
         if !recording && !isPlayerInterrupted && !isResetting {


### PR DESCRIPTION
- fixing crash on teardown custom audio on ios


### Description
on my app it used to crash with the exception:

```
WebRTCWorkerThread(33): Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

within the `stopRendering` function within `OTCustomAudioDriver.swift`