### PR TITLE
Add GitHub Actions to build sample apps

### DIFF
--- a/.github/workflows/sample_test.yml
+++ b/.github/workflows/sample_test.yml
@@ -1,0 +1,52 @@
+name: Test Sample apps
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        project: [BasicVideoChat, Signaling]
+        platform: [ios, android]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Pack Library
+        run: |
+            npm pack
+            find . -name "opentok-react-native-*.tgz" | while read -r file; do mv $file new.tgz; done
+      - name: Checkout samples
+        uses: actions/checkout@v2
+        with:
+          repository: opentok/opentok-react-native-samples
+          path: samples
+      - name: Set up JDK 1.8
+        if: ${{ matrix.platform == 'android' }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: NPM install ${{ matrix.project }}
+        run: |
+          cd samples/${{ matrix.project }}
+          npm install
+          npm install ../../new.tgz
+          cat package.json
+      - name: Build ${{ matrix.project }} ${{ matrix.platform }}
+        run: |
+          cd samples/${{ matrix.project }}/${{ matrix.platform }}
+          if test -f Podfile
+          then 
+            pod install
+            cat Podfile.lock
+            xcodebuild clean build -quiet -workspace ${{ matrix.project }}.xcworkspace -scheme ${{ matrix.project }} -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.4'
+          else
+            ./gradlew app:assembleRelease
+          fi
+          
+          
+  


### PR DESCRIPTION
This PR adds GitHub actions checks to test the version of `opentok-react-native` in a PR against the [sample apps](https://github.com/opentok/opentok-react-native-samples) by building them.

[Running the builds sequentially](https://github.com/opentok/opentok-react-native/actions/runs/860078322) took about 26 mins vs the [parallel runs](https://github.com/opentok/opentok-react-native/actions/runs/860572616) which take about 17. I am sure there can be some optimizations made by caching the NPM packages and Cocoapods but I will try that later. 