### PR TITLE
Update @types

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -61,7 +61,7 @@ declare module "opentok-react-native" {
     stream: Stream;
   }
 
-  interface OTSessionViewProps extends ViewProps {
+  interface OTSessionProps extends ViewProps {
     /**
      * TokBox API Key
      */
@@ -205,9 +205,9 @@ declare module "opentok-react-native" {
   /**
    * https://github.com/opentok/opentok-react-native/blob/master/docs/OTSession.md
    */
-  export class OTSession extends React.Component<OTSessionViewProps> {}
+  export class OTSession extends React.Component<OTSessionProps> {}
 
-  interface OTPublisherViewProps extends ViewProps {
+  interface OTPublisherProps extends ViewProps {
     /**
      * Properties passed into the native publisher instance
      */
@@ -312,9 +312,9 @@ declare module "opentok-react-native" {
   /**
    * https://github.com/opentok/opentok-react-native/blob/master/docs/OTPublisher.md
    */
-  export class OTPublisher extends React.Component<OTPublisherViewProps> {}
+  export class OTPublisher extends React.Component<OTPublisherProps> {}
 
-  interface OTSubscriberViewProps extends ViewProps {
+  interface OTSubscriberProps extends ViewProps {
     /**
      * OpenTok Session Id. This is auto populated by wrapping OTSubscriber with OTSession
      */
@@ -420,7 +420,7 @@ declare module "opentok-react-native" {
     videoNetworkStats?: CallbackWithParam<any, any>;
   }
 
-  interface OTSubscriberView extends ViewProps {
+  interface OTSubscriberViewProps extends ViewProps {
     /**
      * OpenTok Subscriber streamId.
      */
@@ -430,5 +430,5 @@ declare module "opentok-react-native" {
   /**
    * https://github.com/opentok/opentok-react-native/blob/master/docs/OTSubscriber.md
    */
-  export class OTSubscriber extends React.Component<OTSubscriberViewProps> {}
+  export class OTSubscriber extends React.Component<OTSubscriberProps> {}
 }

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -428,6 +428,10 @@ declare module "opentok-react-native" {
   }
 
   /**
+   * https://github.com/opentok/opentok-react-native/blob/main/docs/OTSubscriber.md#custom-rendering-of-streams
+   */
+  export class OTSubscriberView extends React.Component<OTSubscriberViewProps> {}
+  /**
    * https://github.com/opentok/opentok-react-native/blob/master/docs/OTSubscriber.md
    */
   export class OTSubscriber extends React.Component<OTSubscriberProps> {}


### PR DESCRIPTION
Incoming changes:
- Improve type names "OTSession as OTSessionProps" instead of "OTSession as OTSessionViewProps" to have both `OTSubscriberViewProps OTSubscriberView` and `OTSubscriberProps and OTSubscriber`
- Add OTSubscriberView export #503

### Contributing checklist
- [X] Code must follow existing styling conventions
- [X] Added a descriptive commit message

### Solves issue(s)
Closes #503
