### PR TITLE
Fix OTSubscriberView, OTPublishderView layout issue on iOS

### DIFF
--- a/ios/OpenTokReactNative/OTPublisherView.swift
+++ b/ios/OpenTokReactNative/OTPublisherView.swift
@@ -10,19 +10,21 @@ import Foundation
 
 @objc(OTPublisherView)
 class OTPublisherView : UIView {
-  @objc var publisherId: NSString?
+  @objc var publisherId: NSString? {
+    didSet {
+      if let publisherView = OTRN.sharedState.publishers[publisherId! as String]?.view{
+        publisherView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        addSubview(publisherView)
+      }
+    }
+  }
+
   override init(frame: CGRect) {
     super.init(frame: frame)
   }
   
   required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-  override func layoutSubviews() {
-    if let publisherView = OTRN.sharedState.publishers[publisherId! as String]?.view {
-      publisherView.frame = self.bounds
-      addSubview(publisherView)
-    }
   }
 }
 

--- a/ios/OpenTokReactNative/OTPublisherView.swift
+++ b/ios/OpenTokReactNative/OTPublisherView.swift
@@ -12,7 +12,7 @@ import Foundation
 class OTPublisherView : UIView {
   @objc var publisherId: NSString? {
     didSet {
-      if let publisherView = OTRN.sharedState.publishers[publisherId! as String]?.view{
+      if let publisherView = OTRN.sharedState.publishers[publisherId! as String]?.view {
         publisherView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         addSubview(publisherView)
       }

--- a/ios/OpenTokReactNative/OTSubscriberView.swift
+++ b/ios/OpenTokReactNative/OTSubscriberView.swift
@@ -10,20 +10,21 @@ import Foundation
 
 @objc(OTSubscriberView)
 class OTSubscriberView: UIView {
-  @objc var streamId: NSString?
+  @objc var streamId: NSString? {
+    didSet {
+      if let subscriberView = OTRN.sharedState.subscribers[streamId! as String]?.view {
+        subscriberView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        addSubview(subscriberView)
+      }
+    }
+  }
+
   override init(frame: CGRect) {
     super.init(frame: frame)
   }
   
   required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-  
-  override func layoutSubviews() {
-    if let subscriberView = OTRN.sharedState.subscribers[streamId! as String]?.view {
-      subscriberView.frame = self.bounds
-      addSubview(subscriberView)
-    }
   }
 }
 


### PR DESCRIPTION
`OTSubscriberView` and `OTPublisherView` fail to layout properly on iOS. In my case `layoutSubviews` is called only once when the view has incorrect bounds (which are managed by React Native) with height = 0.