### PR TITLE
timeStamp added in videoNetworkStats and audioNetworkStats

### DIFF
--- a/android/src/main/java/com/opentokreactnative/utils/EventUtils.java
+++ b/android/src/main/java/com/opentokreactnative/utils/EventUtils.java
@@ -99,6 +99,7 @@ public final class EventUtils {
         audioStats.putInt("audioPacketsLost", stats.audioPacketsLost);
         audioStats.putInt("audioBytesReceived", stats.audioBytesReceived);
         audioStats.putInt("audioPacketsReceived", stats.audioPacketsReceived);
+        audioStats.putDouble("timeStamp", stats.timeStamp);
         return audioStats;
     }
 
@@ -108,6 +109,7 @@ public final class EventUtils {
         videoStats.putInt("videoPacketsLost", stats.videoPacketsLost);
         videoStats.putInt("videoBytesReceived", stats.videoBytesReceived);
         videoStats.putInt("videoPacketsReceived", stats.videoPacketsReceived);
+        videoStats.putDouble("timeStamp", stats.timeStamp);
         return videoStats;
     }
 

--- a/ios/OpenTokReactNative/Utils/EventUtils.swift
+++ b/ios/OpenTokReactNative/Utils/EventUtils.swift
@@ -61,6 +61,7 @@ class EventUtils {
         videoStatsEventData["videoPacketsLost"] = videoStats.videoPacketsLost;
         videoStatsEventData["videoBytesReceived"] = videoStats.videoBytesReceived;
         videoStatsEventData["videoPacketsReceived"] = videoStats.videoPacketsReceived;
+        videoStatsEventData["timestamp"] = videoStats.timestamp;
         return videoStatsEventData;
     }
     
@@ -69,6 +70,7 @@ class EventUtils {
         audioStatsEventData["audioPacketsLost"] = audioStats.audioPacketsLost;
         audioStatsEventData["audioBytesReceived"] = audioStats.audioBytesReceived;
         audioStatsEventData["audioPacketsReceived"] = audioStats.audioPacketsReceived;
+        audioStatsEventData["timestamp"] = audioStats.timestamp;
         return audioStatsEventData;
     }
     

--- a/ios/OpenTokReactNative/Utils/EventUtils.swift
+++ b/ios/OpenTokReactNative/Utils/EventUtils.swift
@@ -61,7 +61,7 @@ class EventUtils {
         videoStatsEventData["videoPacketsLost"] = videoStats.videoPacketsLost;
         videoStatsEventData["videoBytesReceived"] = videoStats.videoBytesReceived;
         videoStatsEventData["videoPacketsReceived"] = videoStats.videoPacketsReceived;
-        videoStatsEventData["timestamp"] = videoStats.timestamp;
+        videoStatsEventData["timeStamp"] = videoStats.timestamp;
         return videoStatsEventData;
     }
     
@@ -70,7 +70,7 @@ class EventUtils {
         audioStatsEventData["audioPacketsLost"] = audioStats.audioPacketsLost;
         audioStatsEventData["audioBytesReceived"] = audioStats.audioBytesReceived;
         audioStatsEventData["audioPacketsReceived"] = audioStats.audioPacketsReceived;
-        audioStatsEventData["timestamp"] = audioStats.timestamp;
+        audioStatsEventData["timeStamp"] = audioStats.timestamp;
         return audioStatsEventData;
     }
     


### PR DESCRIPTION
To calculate video call quality and audio call quality as per the [https://github.com/opentok/opentok-network-test](https://github.com/opentok/opentok-network-test) we required timestamp in audio and network stat object of subscriber event handler. This PR will help for better calculation of network stats for the conversion of video to audio call. 