### PR TITLE
Fix video freeze issue in Android 13 simulator (API level 33) - fixes #628

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -115,7 +115,9 @@ declare module "opentok-react-native" {
     useTextureViews?: boolean;
 
     /**
-     * Android only - default is false
+     * Android only - default is false.
+     * Deprecated and ignored.
+     
      */
     isCamera2Capable?: boolean;
 

--- a/android/src/main/java/com/opentokreactnative/OTSessionManager.java
+++ b/android/src/main/java/com/opentokreactnative/OTSessionManager.java
@@ -78,7 +78,6 @@ public class OTSessionManager extends ReactContextBaseJavaModule
     public void initSession(String apiKey, String sessionId, ReadableMap sessionOptions) {
 
         final boolean useTextureViews = sessionOptions.getBoolean("useTextureViews");
-        final boolean isCamera2Capable = sessionOptions.getBoolean("isCamera2Capable");
         final boolean connectionEventsSuppressed = sessionOptions.getBoolean("connectionEventsSuppressed");
         final boolean ipWhitelist = sessionOptions.getBoolean("ipWhitelist");
         final boolean enableStereoOutput = sessionOptions.getBoolean("enableStereoOutput");
@@ -102,11 +101,6 @@ public class OTSessionManager extends ReactContextBaseJavaModule
                     @Override
                     public boolean useTextureViews() {
                         return useTextureViews;
-                    }
-
-                    @Override
-                    public boolean isCamera2Capable() {
-                        return isCamera2Capable;
                     }
                 })
                 .connectionEventsSuppressed(connectionEventsSuppressed)

--- a/docs/OTSession.md
+++ b/docs/OTSession.md
@@ -97,7 +97,6 @@ class App extends Component {
       androidZOrder: '', // Android only - valid options are 'mediaOverlay' or 'onTop'
       androidOnTop: '',  // Android only - valid options are 'publisher' or 'subscriber'
       useTextureViews: true,  // Android only - default is false
-      isCamera2Capable: false, // Android only - default is false
       ipWhitelist: false, // https://tokbox.com/developer/sdks/js/reference/OT.html#initSession - ipWhitelist
       enableStereoOutput: true // Enable stereo output, default is false
       iceConfig:{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentok-react-native",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opentok-react-native",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-react-native",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "React Native components for OpenTok iOS and Android SDKs",
   "main": "src/index.js",
   "homepage": "https://www.tokbox.com",

--- a/src/helpers/OTSessionHelper.js
+++ b/src/helpers/OTSessionHelper.js
@@ -96,7 +96,6 @@ const sanitizeSessionOptions = (options) => {
 
   if (platform === 'android') {
     sessionOptions = {
-      isCamera2Capable: false,
       connectionEventsSuppressed: false,
       ipWhitelist: false,
       iceConfig: {},
@@ -131,7 +130,6 @@ const sanitizeSessionOptions = (options) => {
     android: {
       connectionEventsSuppressed: 'boolean',
       useTextureViews: 'boolean',
-      isCamera2Capable: 'boolean',
       androidOnTop: 'string',
       androidZOrder: 'string',
       ipWhitelist: 'boolean',


### PR DESCRIPTION
Setting the isCamera2Capable

<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [√] Code must follow existing styling conventions
- [√] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
Fixes issue #628. 