### PR TITLE
Docs link goes to incorrect file name (.mg / .md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ allprojects {
 
 ## Docs
 
-See the [docs](/docs/index.mg).
+See the [docs](/docs/index.md).
 
 ## Samples
 


### PR DESCRIPTION
One liner, but noticed it in #651

<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message
- [x] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
