### PR TITLE
Docs correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   (2.25) to match the corresponding versions in the OpenTok Android and iOS SDKs.
 
   For iOS, note that this version supports iOS 13+, removes support for FAT binaries
-  and drops 32-bit support.
+  and drops 32-bit support. The OpenTok iOS SDK is now available as the OTXCFramework
+  Pod file. (The OpenTok pod file was for FAT binaries.)
 
   See the release notes for the OpenTok [ioS SDK](https://tokbox.com/developer/sdks/ios/release-notes.html)
   and the [Android SDK](https://tokbox.com/developer/sdks/android/release-notes.html).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you've installed this package before, you may need to edit your `Podfile` and
     target '<YourProjectName>' do
 
       # Pods for <YourProject>
-        pod 'OpenTok', '2.23.1'
+        pod 'OTXCFramework', '2.25.1'
     end
 
 ```


### PR DESCRIPTION
OpenTok iOS SDK is available as OTXCFramework, not OpenTok (FAT binary) framework

### Contributing checklist
- [ ] Code must follow existing styling conventions
- [√] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)