### PR TITLE
Fix android app crash due to permission missing

### DIFF
--- a/src/OT.js
+++ b/src/OT.js
@@ -12,7 +12,8 @@ const checkAndroidPermissions = () => new Promise((resolve, reject) => {
       const permissionsError = {};
       permissionsError.permissionsDenied = [];
       each(result, (permissionValue, permissionType) => {
-        if (permissionValue === 'denied') {
+        // Check if the permission is denied or set to 'never_ask_again'.
+        if (permissionValue === 'denied' || permissionValue === 'never_ask_again' ) {
           permissionsError.permissionsDenied.push(permissionType);
           permissionsError.type = 'Permissions error';
         }


### PR DESCRIPTION
https://jira.vonage.com/browse/VIDECO-9216 

Fix crashes while trying to create a publisher while permission for camera/audio is denied due to the fact we do not consider never_ask_again as an equivalent denied.

 "never_ask_again" is treated as equivalent to "denied" because it signifies that the user has actively chosen not to grant the permission and has selected the option to never be asked again. This is often used as a more restrictive state than simply denied, as it implies that the user does not want the app to ask for permission in the future, even if the app requests it again.
 
 Note: This does not allow publishing without both audio/camera permission as was expected. We can add this as a "feature" in another PR.