### PR TITLE
fix typings for issue 690

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -71,7 +71,7 @@ declare module "opentok-react-native" {
     code: string;
     message: string;
   }
-  
+
   interface SubscriberAudioStatsEvent {
     audioBytesReceived: number,
     audioPacketsLost: number,
@@ -130,35 +130,6 @@ declare module "opentok-react-native" {
     getSessionInfo?: any
 
     /**
-     * Used to get capabilities of the client
-     */
-    getCapabilities(): Promise<{
-      canForceMute: boolean;
-      canPublish: boolean;
-      canSubscribe: boolean;
-    }>
-
-    /**
-     * Mutes all streams in the session.
-     */
-    forceMuteAll(excludedStreamIds: string[]): Promise<>
-
-    /**
-     * Mutes a stream in the session.
-     */
-    forceMuteStream(streamId: string): Promise<>
-
-    /**
-     * Disables the force mute state for the session.
-     */
-    disableForceMute(): Promise<>
-
-    /**
-     * Used to report an issue
-     */
-    reportIssue(): Promise<string>
-
-    /**
      * Event handlers passed into the native session instance.
      */
     eventHandlers?: OTSessionEventHandlers;
@@ -173,9 +144,9 @@ declare module "opentok-react-native" {
     /**
      * EU proxy server URL provided by vonage. Please check https://tokbox.com/developer/guides/eu-proxy/
      */
-     proxyUrl?: string;
+    proxyUrl?: string;
 
-     /**
+    /**
      * Android only - valid options are 'mediaOverlay' or 'onTop'
      */
     androidZOrder?: "mediaOverlay" | "onTop";
@@ -193,7 +164,7 @@ declare module "opentok-react-native" {
     /**
      * Android only - default is false.
      * Deprecated and ignored.
-     
+
      */
     isCamera2Capable?: boolean;
 
@@ -201,7 +172,7 @@ declare module "opentok-react-native" {
      * Whether to use the allowed IP list feature - default is false
      */
     ipWhitelist?: boolean;
-    
+
     /**
      * Enable Stereo output
      */
@@ -213,9 +184,9 @@ declare module "opentok-react-native" {
       includeServers: 'all' | 'custom';
       transportPolicy: 'all' | 'relay';
       customServers: {
-      urls: string[];
-      username?: string;
-      credential?: string;
+        urls: string[];
+        username?: string;
+        credential?: string;
       }[];
     };
   }
@@ -295,7 +266,36 @@ declare module "opentok-react-native" {
   /**
    * https://github.com/opentok/opentok-react-native/blob/master/docs/OTSession.md
    */
-  export class OTSession extends React.Component<OTSessionProps> {}
+  export class OTSession extends React.Component<OTSessionProps, unknown> {
+    /**
+     * Used to get capabilities of the client
+     */
+    getCapabilities: () => Promise<{
+      canForceMute: boolean;
+      canPublish: boolean;
+      canSubscribe: boolean;
+    }>
+
+    /**
+     * Mutes all streams in the session.
+     */
+    forceMuteAll: (excludedStreamIds: string[]) => Promise<void>
+
+    /**
+     * Mutes a stream in the session.
+     */
+    forceMuteStream: (streamId: string) => Promise<void>
+
+    /**
+     * Disables the force mute state for the session.
+     */
+    disableForceMute: () => Promise<void>
+
+    /**
+     * Used to report an issue
+     */
+    reportIssue: () => Promise<string>
+  }
 
   interface OTPublisherProps extends ViewProps {
     /**
@@ -307,13 +307,6 @@ declare module "opentok-react-native" {
      * Event handlers passed into native publsiher instance
      */
     eventHandlers?: OTPublisherEventHandlers;
-
-    /**
-     * Gets the RTC stats report for the publisher. This is an asynchronous operation.
-     * The OTPublisher object dispatches an rtcStatsReport event when RTC statistics for
-     * the publisher are available.
-     */
-    getRtcStatsReport(): void;
   }
 
   interface OTPublisherProperties {
@@ -401,10 +394,10 @@ declare module "opentok-react-native" {
     otrnError?: CallbackWithParam<any, any>;
 
     /**
-     * Sent when RTC stats reports are available for the publisher, 
+     * Sent when RTC stats reports are available for the publisher,
      * in response to calling the OTPublisher.getRtcStatsReport() method.
      */
-    rtcStatsReport?: CallbackWithParam<PublisherRtcStatsReport[]>, any>;
+    rtcStatsReport?: CallbackWithParam<PublisherRtcStatsReport[], any>;
 
     /**
      * Sent when the publisher starts streaming.
@@ -420,7 +413,14 @@ declare module "opentok-react-native" {
   /**
    * https://github.com/opentok/opentok-react-native/blob/master/docs/OTPublisher.md
    */
-  export class OTPublisher extends React.Component<OTPublisherProps> {}
+  export class OTPublisher extends React.Component<OTPublisherProps, unknown> {
+    /**
+     * Gets the RTC stats report for the publisher. This is an asynchronous operation.
+     * The OTPublisher object dispatches an rtcStatsReport event when RTC statistics for
+     * the publisher are available.
+     */
+    getRtcStatsReport?: () => void;
+  }
 
   interface OTSubscriberProps extends ViewProps {
     /**
@@ -452,13 +452,6 @@ declare module "opentok-react-native" {
      * If set to true, the subscriber can subscribe to it's own publisher stream (default: false)
      */
     subscribeToSelf?: boolean;
-
-    /**
-     * Gets the RTC stats report for the subscriber. This is an asynchronous operation.
-     * The OTSubscriber object dispatches an rtcStatsReport event when RTC statistics for
-     * the publisher are available.
-     */
-    getRtcStatsReport(): void;
   }
 
   interface OTSubscriberProperties {
@@ -505,10 +498,10 @@ declare module "opentok-react-native" {
     otrnError?: CallbackWithParam<any, any>;
 
     /**
-     * Sent when an RTC stats report is available for the subscriber, 
+     * Sent when an RTC stats report is available for the subscriber,
      * in response to calling the OTSubscriber.getRtcStatsReport() method.
      */
-    rtcStatsReport?: CallbackWithParam<RtcStatsReport>, any>;
+    rtcStatsReport?: CallbackWithParam<RtcStatsReport, any>;
 
     /**
      * Sent when a frame of video has been decoded. Although the subscriber will connect in a relatively short time, video can take more time to synchronize. This message is sent after the connected message is sent.
@@ -551,9 +544,16 @@ declare module "opentok-react-native" {
   /**
    * https://github.com/opentok/opentok-react-native/blob/main/docs/OTSubscriber.md#custom-rendering-of-streams
    */
-  export class OTSubscriberView extends React.Component<OTSubscriberViewProps> {}
+  export class OTSubscriberView extends React.Component<OTSubscriberViewProps, unknown> {}
   /**
    * https://github.com/opentok/opentok-react-native/blob/master/docs/OTSubscriber.md
    */
-  export class OTSubscriber extends React.Component<OTSubscriberProps> {}
+  export class OTSubscriber extends React.Component<OTSubscriberProps, unknown> {
+    /**
+     * Gets the RTC stats report for the subscriber. This is an asynchronous operation.
+     * The OTSubscriber object dispatches an rtcStatsReport event when RTC statistics for
+     * the publisher are available.
+     */
+    getRtcStatsReport: () => void;
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.25.4 (October 2023)
+
+- [Fix]: Fixes TypeScript definitions  - issue #690.
+
 # 2.25.3 (September 2023)
 
 - [Update]: Add API to implement functionality missing from the OpenTok Android and iOS SDKs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentok-react-native",
-  "version": "2.25.3",
+  "version": "2.25.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opentok-react-native",
-      "version": "2.25.3",
+      "version": "2.25.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-react-native",
-  "version": "2.25.3",
+  "version": "2.25.4",
   "description": "React Native components for OpenTok iOS and Android SDKs",
   "main": "src/index.js",
   "homepage": "https://www.tokbox.com",


### PR DESCRIPTION
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [X ] Code must follow existing styling conventions
- [ X] Added a descriptive commit message
- [x] Sample apps updated if needed => Not Needed (they are not TS projects). Tested changes on my own project though.

### Solves issue(s)
Fixes: https://github.com/opentok/opentok-react-native/issues/690

The typings file was broken. Essentially the basic fixes needed are along those lines:
```
-    rtcStatsReport?: CallbackWithParam<RtcStatsReport>, any>;
+    rtcStatsReport?: CallbackWithParam<RtcStatsReport, any>;
```

Another issue was with the recent typings added on `OTSessionProps`, `OTSubscriberProps` and `OTPublisherProps`

Some methods were added onto the JS component, like `OTSession#getCapabilities`...
However, they are not in fact `props`.

The issue with those typings is that they force consumers of those three components, to fill in those props; despite the fact that they cannot be used anywhere in the component implementations.
The only reason they could be used was if a developer subclassed for example `OTSession`, and then called those props themselves.

Those methods are a part of the components, but using them actually requires subclassing said components. There is no practical way to use them otherwise.

Additionally; `OTSession`, `OTPublisher` and `OTSubscriber` should probably have those functions removed from the declared `propTypes` and `defaultProps`.

I can do that but I need confirmation before I perform that change.

In anycase, if possible this PR could be merged and published quickly in order to fix the typings which are completely broken at the moment.