### PR TITLE
Fixed OTSubscriberEventHandlers type for connected member

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -615,7 +615,7 @@ declare module "opentok-react-native" {
     /**
      * Sent when the subscriber successfully connects to the stream.
      */
-    connected?: Callback<any>;
+    connected?: CallbackWithParam<Stream, any>;
 
     /**
      * Sent when the subscriber receives a caption for the stream.


### PR DESCRIPTION
This PR fixes an incorrect type for the connected `event` in `OTSubscriberEventHandlers`.
Given the following code:
```
const subscriberEventHandlers: OTSubscriberEventHandlers = useMemo(
  () => ({
    connected: (event) => {
      console.log('connected', event)
    }
  }),
  []
)
```
TypeScript throws the warning: `Parameter 'event' implicitly has an 'any' type.`

However, when logging the event, I noticed that it adheres to the `Stream` type. I've updated the library types accordingly to eliminate the warning.
I suspect the same applies to the `disconnected` event, but since I couldn't see it fire in my code I haven't updated it (I wasn't sure about the type for this event).