### PR TITLE
fix: [VIDECO-11315] Fix for multiple publishers bug

### DIFF
--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -97,9 +97,9 @@ export default class OTSubscriber extends Component {
         if (error) {
           this.otrnEventHandler(error);
         } else {
-          this.setState({
-            streams: [...this.state.streams, stream.streamId],
-          });
+          this.setState(prevState => ({
+            streams: [...prevState.streams, stream.streamId],
+          }));
         }
       });
     }


### PR DESCRIPTION
* Updated the `setState` call in `OTSubscriber` to use the functional form, which safely references the previous state when adding a new stream.

<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
This pull request makes a minor improvement to the way state is updated in the `OTSubscriber` component to ensure correct handling of asynchronous state updates.
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
