### PR TITLE
feat: [VIDECO-11201] Added viewScaleBehaviour support

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -8,6 +8,8 @@ declare module 'opentok-react-native' {
 
   type VideoSource = 'screen' | 'camera';
 
+  type VideoScaleType = 'fill' | 'fit';
+
   interface SessionConnectEvent {
     sessionId: string;
     connection: Connection;
@@ -490,6 +492,11 @@ declare module 'opentok-react-native' {
      * The video bitrate preset to use for the published stream. Ignored if maxVideoBitrate is set.
      */
     videoBitratePreset?: 'default' | 'bw_saver' | 'extra_bw_saver';
+
+    /**
+     * Publisher view scale behavior. Defaults to "fill".
+     */
+    scaleBehavior?: VideoScaleType;
   }
 
   interface OTPublisherEventHandlers {
@@ -659,6 +666,11 @@ declare module 'opentok-react-native' {
      * Whether to subscribe video.
      */
     subscribeToVideo?: boolean;
+
+    /**
+     * Subscriber view scale behavior. Defaults to "fill".
+     */
+    scaleBehavior?: VideoScaleType;
   }
 
   interface OTSubscriberEventHandlers {

--- a/ios/OTRNPublisherComponentView.mm
+++ b/ios/OTRNPublisherComponentView.mm
@@ -118,6 +118,7 @@ using namespace facebook::react;
     }
 
     if (oldViewProps.scaleBehavior != newViewProps.scaleBehavior) {
+        NSLog(@"Setting scale behavior to %@", RCTNSStringFromString(newViewProps.scaleBehavior));
         [_impl setScaleBehavior:RCTNSStringFromString(newViewProps.scaleBehavior)];
     }
 

--- a/ios/OTRNPublisherComponentView.mm
+++ b/ios/OTRNPublisherComponentView.mm
@@ -51,6 +51,7 @@ using namespace facebook::react;
         @"allowAudioCaptureWhileMuted" : @(viewProps.allowAudioCaptureWhileMuted),
         @"maxVideoBitrate" : @(viewProps.maxVideoBitrate),
         @"videoBitratePreset" : RCTNSStringFromString(viewProps.videoBitratePreset),
+        @"scaleBehavior": RCTNSStringFromString(viewProps.scaleBehavior),
     };
 }
 
@@ -114,6 +115,10 @@ using namespace facebook::react;
 
     if (oldViewProps.cameraZoomFactor != newViewProps.cameraZoomFactor) {
         [_impl setCameraZoomFactor:newViewProps.cameraZoomFactor];
+    }
+
+    if (oldViewProps.scaleBehavior != newViewProps.scaleBehavior) {
+        [_impl setScaleBehavior:RCTNSStringFromString(newViewProps.scaleBehavior)];
     }
 
     [super updateProps:props oldProps:oldProps];

--- a/ios/OTRNPublisherComponentView.swift
+++ b/ios/OTRNPublisherComponentView.swift
@@ -5,6 +5,7 @@ import React
 @objc public class OTRNPublisherImpl: NSObject {
     private var currentSession: OTSession?
     private var sessionId: String?
+    private let OTPublisherError = "OTPublisherError"
     fileprivate var publisherId: String?
     fileprivate weak var strictUIViewContainer:
         OTRNPublisherComponentView?
@@ -87,7 +88,7 @@ import React
 
         guard let publisherId = self.publisherId else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Publisher ID is not set",
             ])
             return
@@ -100,7 +101,7 @@ import React
             )
         else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message":
                     "There was an error creating the native publisher instance",
             ])
@@ -118,7 +119,7 @@ import React
         {
             guard let screenView = RCTPresentedViewController()?.view else {
                 strictUIViewContainer?.handleError([
-                    "code": "OTPublisherError",
+                    "code": OTPublisherError,
                     "message":
                         "There was an error setting the videoSource as screen",
                 ])
@@ -160,10 +161,9 @@ import React
             }
         }
 
-        if let scaleBehavior = properties["scaleBehavior"] as? String {
-           if(scaleBehavior != "") {
-                publisher.viewScaleBehavior = Utils.convertScaleBehavior(scaleBehavior)
-            }
+        if let scaleBehavior = properties["scaleBehavior"] as? String, !scaleBehavior.isEmpty {
+            print("OTRNPublisherImpl -> Setting scale behavior to \(scaleBehavior)")
+            publisher.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
         }
 
         if let pubView = publisher.view {
@@ -183,7 +183,7 @@ import React
     @objc public func setPublishAudio(_ publishAudio: Bool) {
         guard let publisherId = self.publisherId else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Publisher ID is not set",
             ])
             return
@@ -191,7 +191,7 @@ import React
 
         guard let publisher = OTRN.sharedState.publishers[publisherId] else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Could not find publisher instance",
             ])
             return
@@ -203,7 +203,7 @@ import React
     @objc public func setPublishVideo(_ publishVideo: Bool) {
         guard let publisherId = self.publisherId else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Publisher ID is not set",
             ])
             return
@@ -211,7 +211,7 @@ import React
 
         guard let publisher = OTRN.sharedState.publishers[publisherId] else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Could not find publisher instance",
             ])
             return
@@ -223,7 +223,7 @@ import React
     @objc public func setCameraTorch(_ cameraTorch: Bool) {
         guard let publisherId = self.publisherId else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Publisher ID is not set",
             ])
             return
@@ -231,7 +231,7 @@ import React
 
         guard let publisher = OTRN.sharedState.publishers[publisherId] else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Could not find publisher instance",
             ])
             return
@@ -243,7 +243,7 @@ import React
     @objc public func setCameraZoomFactor(_ cameraZoomFactor: Float) {
         guard let publisherId = self.publisherId else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Publisher ID is not set",
             ])
             return
@@ -251,7 +251,7 @@ import React
 
         guard let publisher = OTRN.sharedState.publishers[publisherId] else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Could not find publisher instance",
             ])
             return
@@ -263,7 +263,7 @@ import React
     @objc public func setVideoContentHint(_ videoContentHint: String) {
         guard let publisherId = self.publisherId else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Publisher ID is not set",
             ])
             return
@@ -271,7 +271,7 @@ import React
 
         guard let publisher = OTRN.sharedState.publishers[publisherId] else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Could not find publisher instance",
             ])
             return
@@ -284,7 +284,7 @@ import React
     @objc public func setMaxVideoBitrate(_ maxVideoBitrate: Int32) {
         guard let publisherId = self.publisherId else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Publisher ID is not set",
             ])
             return
@@ -292,7 +292,7 @@ import React
 
         guard let publisher = OTRN.sharedState.publishers[publisherId] else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Could not find publisher instance",
             ])
             return
@@ -304,7 +304,7 @@ import React
     @objc public func setVideoBitratePreset(_ videoBitratePreset: String) {
         guard let publisherId = self.publisherId else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Publisher ID is not set",
             ])
             return
@@ -312,7 +312,7 @@ import React
 
         guard let publisher = OTRN.sharedState.publishers[publisherId] else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Could not find publisher instance",
             ])
             return
@@ -327,7 +327,7 @@ import React
     @objc public func setScaleBehavior(_ scaleBehavior: String) {
         guard let publisherId = self.publisherId else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Publisher ID is not set",
             ])
             return
@@ -335,15 +335,13 @@ import React
 
         guard let publisher = OTRN.sharedState.publishers[publisherId] else {
             strictUIViewContainer?.handleError([
-                "code": "OTPublisherError",
+                "code": OTPublisherError,
                 "message": "Could not find publisher instance",
             ])
             return
         }
 
-        if (scaleBehavior != "") {
-            publisher.viewScaleBehavior = Utils.convertScaleBehavior(scaleBehavior)
-        }
+        publisher.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
     }
 
     @objc public func cleanup() {
@@ -370,7 +368,7 @@ import React
                     guard let session = OTRN.sharedState.sessions[sessionId]
                     else {
                         self.strictUIViewContainer?.handleError([
-                            "code": "OTPublisherError",
+                            "code": OTPublisherError,
                             "message":
                                 "Error destroying publisher. Could not find native session instance",
                         ])

--- a/ios/OTRNPublisherComponentView.swift
+++ b/ios/OTRNPublisherComponentView.swift
@@ -340,7 +340,7 @@ import React
             ])
             return
         }
-        print("OTRNPublisherImpl -> Setting scale behavior to \(scaleBehavior.toViewScaleBehavior)")
+        print("Setting publisher scale behavior to \(scaleBehavior)")
         publisher.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
     }
 

--- a/ios/OTRNPublisherComponentView.swift
+++ b/ios/OTRNPublisherComponentView.swift
@@ -341,7 +341,8 @@ import React
             return
         }
         print("Setting publisher scale behavior to \(scaleBehavior)")
-        publisher.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
+        publisher.viewScaleBehavior = Utils.convertScaleBehavior(scaleBehavior)
+        // publisher.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
     }
 
     @objc public func cleanup() {

--- a/ios/OTRNPublisherComponentView.swift
+++ b/ios/OTRNPublisherComponentView.swift
@@ -160,6 +160,12 @@ import React
             }
         }
 
+        if let scaleBehavior = properties["scaleBehavior"] as? String {
+           if(scaleBehavior != "") {
+                publisher.viewScaleBehavior = Utils.convertScaleBehavior(scaleBehavior)
+            }
+        }
+
         if let pubView = publisher.view {
             pubView.frame = strictUIViewContainer?.bounds ?? .zero
             publisherUIView = pubView
@@ -315,6 +321,28 @@ import React
         if (videoBitratePreset != "") {
             publisher.videoBitratePreset = 
                 Utils.convertVideoBitratePreset(videoBitratePreset)
+        }
+    }
+
+    @objc public func setScaleBehavior(_ scaleBehavior: String) {
+        guard let publisherId = self.publisherId else {
+            strictUIViewContainer?.handleError([
+                "code": "OTPublisherError",
+                "message": "Publisher ID is not set",
+            ])
+            return
+        }
+
+        guard let publisher = OTRN.sharedState.publishers[publisherId] else {
+            strictUIViewContainer?.handleError([
+                "code": "OTPublisherError",
+                "message": "Could not find publisher instance",
+            ])
+            return
+        }
+
+        if (scaleBehavior != "") {
+            publisher.viewScaleBehavior = Utils.convertScaleBehavior(scaleBehavior)
         }
     }
 

--- a/ios/OTRNPublisherComponentView.swift
+++ b/ios/OTRNPublisherComponentView.swift
@@ -162,7 +162,6 @@ import React
         }
 
         if let scaleBehavior = properties["scaleBehavior"] as? String, !scaleBehavior.isEmpty {
-            print("OTRNPublisherImpl -> Setting scale behavior to \(scaleBehavior)")
             publisher.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
         }
 
@@ -340,9 +339,7 @@ import React
             ])
             return
         }
-        print("Setting publisher scale behavior to \(Utils.convertScaleBehavior(scaleBehavior))")
-        publisher.viewScaleBehavior = Utils.convertScaleBehavior(scaleBehavior)
-        // publisher.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
+        publisher.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
     }
 
     @objc public func cleanup() {

--- a/ios/OTRNPublisherComponentView.swift
+++ b/ios/OTRNPublisherComponentView.swift
@@ -340,7 +340,7 @@ import React
             ])
             return
         }
-        print("Setting publisher scale behavior to \(scaleBehavior)")
+        print("Setting publisher scale behavior to \(Utils.convertScaleBehavior(scaleBehavior))")
         publisher.viewScaleBehavior = Utils.convertScaleBehavior(scaleBehavior)
         // publisher.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
     }

--- a/ios/OTRNPublisherComponentView.swift
+++ b/ios/OTRNPublisherComponentView.swift
@@ -340,7 +340,7 @@ import React
             ])
             return
         }
-
+        print("OTRNPublisherImpl -> Setting scale behavior to \(scaleBehavior.toViewScaleBehavior)")
         publisher.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
     }
 

--- a/ios/OTRNSubscriberComponentView.mm
+++ b/ios/OTRNSubscriberComponentView.mm
@@ -69,7 +69,8 @@ using namespace facebook::react;
             @"sessionId": RCTNSStringFromString(newViewProps.sessionId),
             @"streamId": RCTNSStringFromString(newViewProps.streamId),
             @"subscribeToAudio": @(newViewProps.subscribeToAudio),
-            @"subscribeToVideo": @(newViewProps.subscribeToVideo)
+            @"subscribeToVideo": @(newViewProps.subscribeToVideo),
+            @"scaleBehavior": RCTNSStringFromString(newViewProps.scaleBehavior)
         };
         [_impl createSubscriber:subscriberProperties];
         self.contentView = _impl.subscriberView;
@@ -89,6 +90,10 @@ using namespace facebook::react;
 
     if (oldViewProps.subscribeToVideo != newViewProps.subscribeToVideo) {
         [_impl setSubscribeToVideo:newViewProps.subscribeToVideo];
+    }
+
+    if (oldViewProps.scaleBehavior != newViewProps.scaleBehavior) {
+        [_impl setScaleBehavior:RCTNSStringFromString(newViewProps.scaleBehavior)];
     }
 
     [super updateProps:props oldProps:oldProps];

--- a/ios/OTRNSubscriberComponentView.swift
+++ b/ios/OTRNSubscriberComponentView.swift
@@ -91,7 +91,7 @@ import React
             properties["preferredFrameRate"] as Any)
         subscriber.preferredResolution = Utils.sanitizePreferredResolution(
             properties["preferredResolution"] as Any)
-        subscriber.viewScaleBehavior = properties["scaleBehavior"].toViewScaleBehavior
+        subscriber.viewScaleBehavior = Utils.sanitizeStringProperty(properties["scaleBehavior"]).toViewScaleBehavior
 
         var error: OTError?
         session.subscribe(subscriber, error: &error)

--- a/ios/OTRNSubscriberComponentView.swift
+++ b/ios/OTRNSubscriberComponentView.swift
@@ -91,9 +91,7 @@ import React
             properties["preferredFrameRate"] as Any)
         subscriber.preferredResolution = Utils.sanitizePreferredResolution(
             properties["preferredResolution"] as Any)
-        subscriber.viewScaleBehavior = Utils.convertScaleBehavior(
-            Utils.sanitizeStringProperty(
-                properties["scaleBehavior"] as Any))
+        subscriber.viewScaleBehavior = properties["scaleBehavior"].toViewScaleBehavior
 
         var error: OTError?
         session.subscribe(subscriber, error: &error)
@@ -149,7 +147,7 @@ import React
     @objc public func setScaleBehavior(_ scaleBehavior: String) {
         guard let subscriber = OTRN.sharedState.subscribers[streamId ?? ""]
         else { return }
-        subscriber.viewScaleBehavior = Utils.convertScaleBehavior(scaleBehavior)
+        subscriber.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
     }
 
     @objc public func cleanup() {

--- a/ios/OTRNSubscriberComponentView.swift
+++ b/ios/OTRNSubscriberComponentView.swift
@@ -91,6 +91,9 @@ import React
             properties["preferredFrameRate"] as Any)
         subscriber.preferredResolution = Utils.sanitizePreferredResolution(
             properties["preferredResolution"] as Any)
+        subscriber.viewScaleBehavior = Utils.convertScaleBehavior(
+            Utils.sanitizeStringProperty(
+                properties["scaleBehavior"] as Any))
 
         var error: OTError?
         session.subscribe(subscriber, error: &error)
@@ -141,6 +144,12 @@ import React
         guard let subscriber = OTRN.sharedState.subscribers[streamId ?? ""]
         else { return }
         subscriber.subscribeToCaptions = subscribeToCaptions
+    }
+
+    @objc public func setScaleBehavior(_ scaleBehavior: String) {
+        guard let subscriber = OTRN.sharedState.subscribers[streamId ?? ""]
+        else { return }
+        subscriber.viewScaleBehavior = Utils.convertScaleBehavior(scaleBehavior)
     }
 
     @objc public func cleanup() {

--- a/ios/Utils/Utils.swift
+++ b/ios/Utils/Utils.swift
@@ -208,6 +208,7 @@ class Utils {
         guard let behavior = scaleBehavior as? String else {
             return .fill
         }
+        print("Converting subscriber scale behavior string: \(behavior)")
         switch behavior {
         case "fill":
             return .fill

--- a/ios/Utils/Utils.swift
+++ b/ios/Utils/Utils.swift
@@ -205,7 +205,6 @@ class Utils {
     static func convertScaleBehavior(_ scaleBehavior: Any)
         -> OTVideoViewScaleBehavior
     {
-        print("Converting scale behavior: \(scaleBehavior)")
         guard let behavior = scaleBehavior as? String else {
             return .fill
         }

--- a/ios/Utils/Utils.swift
+++ b/ios/Utils/Utils.swift
@@ -201,21 +201,6 @@ class Utils {
             return OTVideoBitratePreset.default
         }
     }
-
-    static func convertScaleBehavior(_ scaleBehavior: Any)
-        -> OTVideoViewScaleBehavior
-    {
-        guard let behavior = scaleBehavior as? String else {
-            return .fill
-        }
-        print("Converting subscriber scale behavior string: \(behavior)")
-        switch behavior {
-        case "fill":
-            return .fill
-        default:
-            return .fit
-        }
-    }
     static func setStreamObservers(stream: OTStream, isPublisherStream: Bool) {
         let streamId = stream.streamId
 
@@ -336,7 +321,6 @@ class Utils {
 
 extension String {
     var toViewScaleBehavior: OTVideoViewScaleBehavior {
-        print("Converting scale behavior string: \(self)")
         switch self {
         case "fit":
             return .fit

--- a/ios/Utils/Utils.swift
+++ b/ios/Utils/Utils.swift
@@ -332,3 +332,15 @@ class Utils {
         OTRN.sharedState.opentokModule?.emit(onStreamPropertyChanged: eventData)
     }
 }
+
+extension String {
+    var toViewScaleBehavior: OTVideoViewScaleBehavior {
+        print("Converting scale behavior string: \(self)")
+        switch self {
+        case "fit":
+            return .fit
+        default:
+            return .fill
+        }
+    }
+}

--- a/ios/Utils/Utils.swift
+++ b/ios/Utils/Utils.swift
@@ -201,6 +201,21 @@ class Utils {
             return OTVideoBitratePreset.default
         }
     }
+
+    static func convertScaleBehavior(_ scaleBehavior: Any)
+        -> OTVideoViewScaleBehavior
+    {
+        print("Converting scale behavior: \(scaleBehavior)")
+        guard let behavior = scaleBehavior as? String else {
+            return .fill
+        }
+        switch behavior {
+        case "fill":
+            return .fill
+        default:
+            return .fit
+        }
+    }
     static func setStreamObservers(stream: OTStream, isPublisherStream: Bool) {
         let streamId = stream.streamId
 

--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -244,6 +244,7 @@ OTPublisher.defaultProps = {
     videoContentHint: '',
     maxVideoBitrate: 0,
     videoBitratePreset: 'default',
+    scaleBehavior: 'fill',
   },
   style: {
     flex: 1,

--- a/src/OTPublisherNativeComponent.ts
+++ b/src/OTPublisherNativeComponent.ts
@@ -58,6 +58,7 @@ export interface NativeProps extends ViewProps {
   videoContentHint?: string;
   maxVideoBitrate?: Int32;
   videoBitratePreset?: string;
+  scaleBehavior?: string;
 
   onError?: BubblingEventHandler<ErrorEvent> | null;
   onStreamCreated?: BubblingEventHandler<StreamEvent> | null;

--- a/src/OTSubscriberNativeComponent.ts
+++ b/src/OTSubscriberNativeComponent.ts
@@ -70,6 +70,7 @@ export interface NativeProps extends ViewProps {
   streamId: string;
   subscribeToAudio?: boolean;
   subscribeToVideo?: boolean;
+  scaleBehavior?: string;
 
   subscribeToCaptions?: boolean;
   audioVolume?: Float;

--- a/src/OTSubscriberView.js
+++ b/src/OTSubscriberView.js
@@ -8,6 +8,7 @@ export default class OTSubscriberView extends React.Component {
   static defaultProps = {
     subscribeToAudio: true,
     subscribeToVideo: true,
+    scaleBehavior: 'fill',
     style: {
       flex: 1,
     },
@@ -61,6 +62,10 @@ export default class OTSubscriberView extends React.Component {
       streamProperties?.subscribeToAudio ??
       subscriberProperties?.subscribeToAudio ??
       true;
+    const scaleBehavior =
+      streamProperties?.scaleBehavior ??
+      subscriberProperties?.scaleBehavior ??
+      'fill';
     const style = streamProperties?.style || this.context.style;
     return (
       <OTRNSubscriber
@@ -68,6 +73,7 @@ export default class OTSubscriberView extends React.Component {
         streamId={streamId}
         subscribeToAudio={subscribeToAudio}
         subscribeToVideo={subscribeToVideo}
+        scaleBehavior={scaleBehavior}
         subscribeToCaptions={subscribeToCaptions}
         preferredFrameRate={preferredFrameRate}
         preferredResolution={preferredResolution}

--- a/src/helpers/OTPublisherHelper.js
+++ b/src/helpers/OTPublisherHelper.js
@@ -175,7 +175,7 @@ const sanitizeProperties = (properties) => {
       properties.videoBitratePreset,
       properties.maxVideoBitrate
     ),
-    scaleBehavior: properties.scaleBehavior ? properties.scaleBehavior : 'fill',
+    scaleBehavior: properties.scaleBehavior ?? 'fill',
   };
 };
 

--- a/src/helpers/OTPublisherHelper.js
+++ b/src/helpers/OTPublisherHelper.js
@@ -175,6 +175,7 @@ const sanitizeProperties = (properties) => {
       properties.videoBitratePreset,
       properties.maxVideoBitrate
     ),
+    scaleBehavior: properties.scaleBehavior ? properties.scaleBehavior : 'fill',
   };
 };
 

--- a/src/helpers/OTSubscriberHelper.js
+++ b/src/helpers/OTSubscriberHelper.js
@@ -68,6 +68,7 @@ const sanitizeProperties = (properties) => {
       preferredResolution: sanitizeResolution(null),
       preferredFrameRate: sanitizeFrameRate(null),
       audioVolume: 100,
+      scaleBehavior: 'fill',
     };
   }
   return {
@@ -79,6 +80,7 @@ const sanitizeProperties = (properties) => {
     preferredResolution: sanitizeResolution(properties.preferredResolution),
     preferredFrameRate: sanitizeFrameRate(properties.preferredFrameRate),
     audioVolume: sanitizeAudioVolume(properties.audioVolume),
+    scaleBehavior: properties.scaleBehavior ? properties.scaleBehavior : 'fill',
   };
 };
 
@@ -91,6 +93,7 @@ const sanitizeStreamProperties = (streamProperties) => {
       preferredResolution,
       preferredFrameRate,
       audioVolume,
+      scaleBehavior,
     } = individualStreamProperties;
     if (subscribeToAudio !== undefined) {
       individualStreamProperties.subscribeToAudio =
@@ -114,6 +117,9 @@ const sanitizeStreamProperties = (streamProperties) => {
     }
     if (audioVolume !== undefined) {
       individualStreamProperties.audioVolume = sanitizeAudioVolume(audioVolume);
+    }
+    if (scaleBehavior !== undefined) {
+      individualStreamProperties.scaleBehavior = scaleBehavior;
     }
   });
 };


### PR DESCRIPTION
This pull request adds support for a new `scaleBehavior` property to both publisher and subscriber video components, allowing control over how video is scaled (e.g., 'fill' or 'fit'). The change is implemented across the JavaScript and iOS native code, including default values, property sanitization, and native method handling.

**Publisher and Subscriber Video Scaling Support:**

* Added `scaleBehavior` as a prop to both `OTPublisher` and `OTSubscriber` components, with a default value of `'fill'`. This is reflected in their TypeScript interfaces and defaultProps. [[1]](diffhunk://#diff-25feee9927a2fe35579b19c4854d6ede42842177158be4099a4e2c9a835f00aaR247) [[2]](diffhunk://#diff-afc2753d06fd796f17f00b6690caa429f2dcbc9503bb85c730af42bb482db20bR61) [[3]](diffhunk://#diff-5a11998642e066c710b71ff49342ead9c3b075115c1c128d2e1149d563d99d12R73) [[4]](diffhunk://#diff-ecca2b9b16c16952ac1fe9eab71ed98b253905ce4961df83ae19a918d4754644R11)
* Updated helper functions (`OTPublisherHelper.js` and `OTSubscriberHelper.js`) to sanitize and provide default values for `scaleBehavior`. [[1]](diffhunk://#diff-509caab617f208b1ab74bde16d44b81896e4051379adda7e3bb486b26d5210e3R178) [[2]](diffhunk://#diff-f4d97e9e7886267f16eb038b963e21a94435994f82a5633686fa53f02452d2b7R71) [[3]](diffhunk://#diff-f4d97e9e7886267f16eb038b963e21a94435994f82a5633686fa53f02452d2b7R83) [[4]](diffhunk://#diff-f4d97e9e7886267f16eb038b963e21a94435994f82a5633686fa53f02452d2b7R96) [[5]](diffhunk://#diff-f4d97e9e7886267f16eb038b963e21a94435994f82a5633686fa53f02452d2b7R121-R123)
* Modified the rendering logic in `OTSubscriberView.js` to pass the correct `scaleBehavior` down to the native component.

**iOS Native Implementation:**

* Updated native view components (`OTRNPublisherComponentView.mm`, `OTRNSubscriberComponentView.mm`, `OTRNPublisherComponentView.swift`, `OTRNSubscriberComponentView.swift`) to accept and react to changes in the `scaleBehavior` property, including updating the view when the property changes. [[1]](diffhunk://#diff-4bcfdbbf211a3037c9553713974762d68274f45e649e2409a4a54618bf5be6b4R54) [[2]](diffhunk://#diff-4bcfdbbf211a3037c9553713974762d68274f45e649e2409a4a54618bf5be6b4R120-R123) [[3]](diffhunk://#diff-e980c2ba33ed1b270377c7fd7a8f33ef1d869f75456e0b33881f1fca53d79366L72-R73) [[4]](diffhunk://#diff-e980c2ba33ed1b270377c7fd7a8f33ef1d869f75456e0b33881f1fca53d79366R95-R98) [[5]](diffhunk://#diff-23351afc95835e295ee29b1fefe21521a4e7ba2136f9ba8270c71b243e1207cfR163-R168) [[6]](diffhunk://#diff-23351afc95835e295ee29b1fefe21521a4e7ba2136f9ba8270c71b243e1207cfR327-R348) [[7]](diffhunk://#diff-e0870a38587b4e420e3965636d86b88960763368d64243e06184c49c2936684dR94-R96) [[8]](diffhunk://#diff-e0870a38587b4e420e3965636d86b88960763368d64243e06184c49c2936684dR149-R154)
* Added the `Utils.convertScaleBehavior` helper in Swift to map the string value to the appropriate native video scale behavior enum, defaulting to `.fill` or `.fit`.
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
