### PR TITLE
Added videoScale support for Android

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
@@ -202,7 +202,7 @@ class OTRNPublisher : FrameLayout, PublisherListener,
         )
     }
 
-    private fun publishStream(/*session: Session*/) {
+    private fun publishStream() {
         var pubOrSub: String? = ""
         var zOrder: String? = ""
         if (this.props?.get("videoSource") == "screen") {

--- a/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
@@ -195,10 +195,9 @@ class OTRNPublisher : FrameLayout, PublisherListener,
     }
 
     public fun setScaleBehavior(value: String?) {
-        val videoScaleType = Utils.convertVideoScaleType(value)
         publisher?.setStyle(
             BaseVideoRenderer.STYLE_VIDEO_SCALE,
-            videoScaleType
+            Utils.convertVideoScaleType(value)
         )
     }
 
@@ -255,7 +254,7 @@ class OTRNPublisher : FrameLayout, PublisherListener,
         publisher?.setPublishCaptions(this.props?.get("publishCaptions") as Boolean)
         publisher?.setStyle(
             BaseVideoRenderer.STYLE_VIDEO_SCALE,
-            BaseVideoRenderer.STYLE_VIDEO_FILL
+            Utils.convertVideoScaleType(this.props?.get("scaleBehavior") as String)
         )
 
         if (androidOnTopMap.get(sessionId) != null) {

--- a/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
@@ -194,6 +194,14 @@ class OTRNPublisher : FrameLayout, PublisherListener,
         // Ignore -- set as initialization option only
     }
 
+    public fun setScaleBehavior(value: String?) {
+        val videoScaleType = Utils.convertVideoScaleType(value)
+        publisher?.setStyle(
+            BaseVideoRenderer.STYLE_VIDEO_SCALE,
+            videoScaleType
+        )
+    }
+
     private fun publishStream(/*session: Session*/) {
         var pubOrSub: String? = ""
         var zOrder: String? = ""

--- a/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
@@ -20,6 +20,7 @@ import com.opentok.android.PublisherKit.PublisherListener
 import com.opentok.android.Stream
 import com.opentokreactnative.utils.EventUtils;
 import com.opentokreactnative.utils.Utils
+import com.opentokreactnative.utils.toVideoScaleType;
 
 class OTRNPublisher : FrameLayout, PublisherListener,
     PublisherKit.AudioLevelListener,
@@ -197,7 +198,7 @@ class OTRNPublisher : FrameLayout, PublisherListener,
     public fun setScaleBehavior(value: String?) {
         publisher?.setStyle(
             BaseVideoRenderer.STYLE_VIDEO_SCALE,
-            Utils.convertVideoScaleType(value)
+            value.toVideoScaleType()
         )
     }
 
@@ -254,7 +255,7 @@ class OTRNPublisher : FrameLayout, PublisherListener,
         publisher?.setPublishCaptions(this.props?.get("publishCaptions") as Boolean)
         publisher?.setStyle(
             BaseVideoRenderer.STYLE_VIDEO_SCALE,
-            Utils.convertVideoScaleType(this.props?.get("scaleBehavior") as String)
+            (this.props?.get("scaleBehavior") as String).toVideoScaleType()
         )
 
         if (androidOnTopMap.get(sessionId) != null) {

--- a/android/src/main/java/com/opentokreactnative/OTRNPublisherManager.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNPublisherManager.kt
@@ -171,6 +171,11 @@ class OTRNPublisherManager(context: ReactApplicationContext) :
         view.setAllowAudioCaptureWhileMuted(value)
     }
 
+    @ReactProp(name = "scaleBehavior")
+    override public fun setScaleBehavior(view: OTRNPublisher, value: String?) {
+        view.setScaleBehavior(value)
+    }
+
     companion object {
         const val REACT_CLASS = "OTRNPublisher"
     }

--- a/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
@@ -19,6 +19,7 @@ import com.opentok.android.SubscriberKit
 import com.opentok.android.SubscriberKit.SubscriberListener
 import com.opentok.android.SubscriberKit.SubscriberRtcStatsReportListener
 import com.opentok.android.VideoUtils
+import com.opentokreactnative.utils.Utils;
 import com.opentokreactnative.utils.EventUtils;
 import kotlin.collections.component1
 import kotlin.collections.component2
@@ -185,6 +186,14 @@ class OTRNSubscriber : FrameLayout, SubscriberListener,
             this.addView(subscriber?.view)
             requestLayout()
         }
+    }
+
+    public fun setScaleBehavior(value: String?) {
+        val videoScaleType = Utils.convertVideoScaleType(value)
+        subscriber?.setStyle(
+            BaseVideoRenderer.STYLE_VIDEO_SCALE,
+            videoScaleType
+        )
     }
 
     override fun onConnected(subscriber: SubscriberKit) {

--- a/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
@@ -129,7 +129,7 @@ class OTRNSubscriber : FrameLayout, SubscriberListener,
         sharedState.getSubscribers().put(stream.getStreamId(), subscriber ?: return);
         subscriber?.setStyle(
             BaseVideoRenderer.STYLE_VIDEO_SCALE,
-            BaseVideoRenderer.STYLE_VIDEO_FILL
+            Utils.convertVideoScaleType(this.props?.get("scaleBehavior") as String)
         )
 
         if (androidOnTopMap.get(sessionId) != null) {
@@ -189,10 +189,9 @@ class OTRNSubscriber : FrameLayout, SubscriberListener,
     }
 
     public fun setScaleBehavior(value: String?) {
-        val videoScaleType = Utils.convertVideoScaleType(value)
         subscriber?.setStyle(
             BaseVideoRenderer.STYLE_VIDEO_SCALE,
-            videoScaleType
+            Utils.convertVideoScaleType(value)
         )
     }
 

--- a/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
@@ -21,6 +21,7 @@ import com.opentok.android.SubscriberKit.SubscriberRtcStatsReportListener
 import com.opentok.android.VideoUtils
 import com.opentokreactnative.utils.Utils;
 import com.opentokreactnative.utils.EventUtils;
+import com.opentokreactnative.utils.toVideoScaleType;
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.iterator
@@ -129,7 +130,7 @@ class OTRNSubscriber : FrameLayout, SubscriberListener,
         sharedState.getSubscribers().put(stream.getStreamId(), subscriber ?: return);
         subscriber?.setStyle(
             BaseVideoRenderer.STYLE_VIDEO_SCALE,
-            Utils.convertVideoScaleType(this.props?.get("scaleBehavior") as String)
+            (this.props?.get("scaleBehavior") as String).toVideoScaleType()
         )
 
         if (androidOnTopMap.get(sessionId) != null) {
@@ -191,7 +192,7 @@ class OTRNSubscriber : FrameLayout, SubscriberListener,
     public fun setScaleBehavior(value: String?) {
         subscriber?.setStyle(
             BaseVideoRenderer.STYLE_VIDEO_SCALE,
-            Utils.convertVideoScaleType(value)
+            value.toVideoScaleType()
         )
     }
 

--- a/android/src/main/java/com/opentokreactnative/OTRNSubscriberManager.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNSubscriberManager.kt
@@ -35,6 +35,11 @@ class OTRNSubscriberManager(context: ReactApplicationContext) :
         view.setSessionId(sessionId)
     }
 
+    @ReactProp(name = "scaleBehavior")
+    override public fun setScaleBehavior(view: OTRNSubscriber, value: String?) {
+        view.setScaleBehavior(value)
+    }
+
     override fun setSubscribeToAudio(
         view: OTRNSubscriber?,
         value: Boolean

--- a/android/src/main/java/com/opentokreactnative/utils/KotlinUtils.kt
+++ b/android/src/main/java/com/opentokreactnative/utils/KotlinUtils.kt
@@ -1,0 +1,12 @@
+// We need to replace Java with Kotlin
+// This file to add/migrate the Utility functions from Utils.java to Utils.kt
+
+package com.opentokreactnative.utils
+
+import com.opentok.android.BaseVideoRenderer
+
+fun String?.toVideoScaleType(): String = when (this) {
+    "fit" -> BaseVideoRenderer.STYLE_VIDEO_FIT
+    "fill" -> BaseVideoRenderer.STYLE_VIDEO_FILL
+    else -> BaseVideoRenderer.STYLE_VIDEO_FILL
+}

--- a/android/src/main/java/com/opentokreactnative/utils/Utils.java
+++ b/android/src/main/java/com/opentokreactnative/utils/Utils.java
@@ -158,15 +158,4 @@ public final class Utils {
                 return VideoBitratePreset.VideoBitratePresetDefault;
         }
     }
-
-    public static String convertVideoScaleType(String rendererType) {
-        switch (rendererType) {
-            case "fit":
-                return BaseVideoRenderer.STYLE_VIDEO_FIT;
-            case "fill":
-                return BaseVideoRenderer.STYLE_VIDEO_FILL;
-            default:
-                return BaseVideoRenderer.STYLE_VIDEO_FILL;
-        }
-    }
 }

--- a/android/src/main/java/com/opentokreactnative/utils/Utils.java
+++ b/android/src/main/java/com/opentokreactnative/utils/Utils.java
@@ -8,6 +8,7 @@ import com.opentok.android.PublisherKit.VideoTransformer;
 import com.opentok.android.PublisherKit.VideoBitratePreset;
 import com.opentok.android.Subscriber;
 import com.opentok.android.SubscriberKit;
+import com.opentok.android.BaseVideoRenderer;
 import com.opentok.android.Session.Builder.TransportPolicy;
 import com.opentok.android.Session.Builder.IncludeServers;
 import com.opentok.android.Session.Builder.IceServer;
@@ -147,7 +148,7 @@ public final class Utils {
         }
     }
 
-public static VideoBitratePreset convertVideoBitratePreset(String videoBitratePreset) {
+    public static VideoBitratePreset convertVideoBitratePreset(String videoBitratePreset) {
         switch (videoBitratePreset) {
             case "bw_saver":
                 return VideoBitratePreset.VideoBitratePresetBwSaver;
@@ -155,6 +156,17 @@ public static VideoBitratePreset convertVideoBitratePreset(String videoBitratePr
                 return VideoBitratePreset.VideoBitratePresetExtraBwSaver;
             default:
                 return VideoBitratePreset.VideoBitratePresetDefault;
+        }
+    }
+
+    public static String convertVideoScaleType(String rendererType) {
+        switch (rendererType) {
+            case "fit":
+                return BaseVideoRenderer.STYLE_VIDEO_FIT;
+            case "fill":
+                return BaseVideoRenderer.STYLE_VIDEO_FILL;
+            default:
+                return BaseVideoRenderer.STYLE_VIDEO_FILL;
         }
     }
 }


### PR DESCRIPTION
This pull request adds support for configuring the video scale behavior (fit/fill) for both publishers and subscribers in the OpenTok React Native Android implementation. The main changes introduce a new `scaleBehavior` prop, utility conversion logic, and the necessary wiring to apply the style at runtime.

**Video scale behavior support:**

* Added a `setScaleBehavior` method to both `OTRNPublisher` and `OTRNSubscriber` classes, allowing the video rendering style to be set dynamically using the new `scaleBehavior` prop. This uses a utility function to convert the prop value to the appropriate OpenTok constant. [[1]](diffhunk://#diff-cdb71b2bb1494383cafc1a34f697cde6d3be55d8d4146184cd239ee55e8647c2R197-R204) [[2]](diffhunk://#diff-56ef796f275f56e948c6dcd72457e91d4e3745f58f65427a3266fa9ad4ffcc0eR191-R198)
* Updated `OTRNPublisherManager` and `OTRNSubscriberManager` to expose the `scaleBehavior` prop to React Native, calling the new setter methods on their respective views. [[1]](diffhunk://#diff-85501801390dcb1b70665769e597b579c032720819016109f0a3c52e07e389fdR174-R178) [[2]](diffhunk://#diff-16d34b33960d439dc309b0ed4c744c2500a3ec49fd9eb60c7e4a327804dad35aR38-R42)

**Utility function:**

* Added `convertVideoScaleType` to `Utils.java` to map string values (`"fit"`, `"fill"`) to the corresponding `BaseVideoRenderer` style constants, defaulting to fill if unrecognized.
* Imported `BaseVideoRenderer` in `Utils.java` and ensured the utility is available where needed. [[1]](diffhunk://#diff-f17eb05ef66c1c764ef85814a89fb511256af1e1d23df9b05d9ee85ff10d3b5eR11) [[2]](diffhunk://#diff-56ef796f275f56e948c6dcd72457e91d4e3745f58f65427a3266fa9ad4ffcc0eR22)
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
