### PR TITLE
fix(ScreenCapturer)[VIDECO-11319]: Fix for failed screen sharing on Android

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTScreenCapturer.java
+++ b/android/src/main/java/com/opentokreactnative/OTScreenCapturer.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.os.Handler;
 import android.view.View;
+import android.os.Looper;
 
 import com.opentok.android.BaseVideoCapturer;
 
@@ -21,14 +22,26 @@ public class OTScreenCapturer extends BaseVideoCapturer {
     private Bitmap bmp;
     private Canvas canvas;
 
-    private Handler mHandler = new Handler();
+    private Handler mHandler = new Handler(Looper.getMainLooper());
 
     private Runnable newFrame = new Runnable() {
         @Override
         public void run() {
             if (capturing) {
+                // Check if the view is attached and has dimensions
+                if (contentView == null || !contentView.isAttachedToWindow()) {
+                    mHandler.postDelayed(newFrame, 1000 / fps);
+                    return;
+                }
+
                 int width = contentView.getWidth();
                 int height = contentView.getHeight();
+
+                // Skip frame if dimensions are zero
+                if (width <= 0 || height <= 0) {
+                    mHandler.postDelayed(newFrame, 1000 / fps);
+                    return;
+                }
 
                 if (frame == null ||
                         OTScreenCapturer.this.width != width ||


### PR DESCRIPTION
This pull request improves the stability and reliability of the `OTScreenCapturer` class by ensuring frame capture only occurs when the view is properly attached and has valid dimensions. It also updates the handler initialization to use the main thread's looper, which is best practice for UI operations.

**Stability and reliability improvements:**

* Added checks in the frame capture routine to ensure `contentView` is attached to the window and has non-zero dimensions before capturing a frame, preventing errors and unnecessary processing.

**Code quality and best practices:**

* Updated the initialization of `mHandler` to use `Looper.getMainLooper()`, ensuring that UI-related operations are executed on the main thread.
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
