### PR TITLE
fix(VIDECO-11444): Screen sharing support for a new architecture

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTScreenCapturer.java
+++ b/android/src/main/java/com/opentokreactnative/OTScreenCapturer.java
@@ -64,7 +64,12 @@ public class OTScreenCapturer extends BaseVideoCapturer {
     };
 
     public OTScreenCapturer(View view) {
-        this.contentView = view;
+        View parentView = (View) view.getParent();
+        if (parentView != null) {
+            this.contentView = parentView; // Use ReactSurfaceView in a NewArchitecture
+        } else {
+            this.contentView = view; // Fallback
+        }
     }
 
     @Override

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "axios": "^1.6.8",
+    "axios": "^1.13.2",
     "deprecated-react-native-prop-types": "5.0.0",
     "react-native-uuid": "^2.0.3",
     "underscore": "^1.13.7"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "axios": "^1.12.0",
+    "axios": "^1.6.8",
     "deprecated-react-native-prop-types": "5.0.0",
     "react-native-uuid": "^2.0.3",
     "underscore": "^1.13.7"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "axios": "^1.6.8",
+    "axios": "^1.12.0",
     "deprecated-react-native-prop-types": "5.0.0",
     "react-native-uuid": "^2.0.3",
     "underscore": "^1.13.7"

--- a/src/helpers/OTHelper.js
+++ b/src/helpers/OTHelper.js
@@ -45,7 +45,7 @@ const logRequest = (body, proxyUrl) => {
     data: body,
   })
     .then(() => {
-      console.log('OT log sent');
+      console.log('OT log sent 1.13.2');
       // response complete
     })
     .catch(() => {

--- a/src/helpers/OTHelper.js
+++ b/src/helpers/OTHelper.js
@@ -45,7 +45,6 @@ const logRequest = (body, proxyUrl) => {
     data: body,
   })
     .then(() => {
-      console.log('OT log sent 1.13.2');
       // response complete
     })
     .catch(() => {

--- a/src/helpers/OTHelper.js
+++ b/src/helpers/OTHelper.js
@@ -45,6 +45,7 @@ const logRequest = (body, proxyUrl) => {
     data: body,
   })
     .then(() => {
+      console.log('OT log sent');
       // response complete
     })
     .catch(() => {


### PR DESCRIPTION
This pull request introduces an update to a dependency version and improves the initialization logic for a screen capturer component to better support React Native's new architecture.

Dependency update:

* Upgraded the `axios` package version in `package.json` from `^1.6.8` to `^1.13.2` to include the latest features and security fixes.

React Native architecture compatibility:

* Modified the constructor in `OTScreenCapturer.java` to use the parent view (typically `ReactSurfaceView`) if available, improving compatibility with React Native's New Architecture. Falls back to the provided view if no parent is present.
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
