### PR TITLE
VIDCS-4016: Service Catalog Rollout file additions to Video API Client SDK repositories

### DIFF
--- a/.vonage/catalog-info.yaml
+++ b/.vonage/catalog-info.yaml
@@ -26,7 +26,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: video-react-native-sdks
-  description: OpenTok React Native - a library for OpenTok iOS and Android SDKs
+  description: React Native module for the Vonage Video API
   annotations:
     github.com/project-slug: opentok/opentok-react-native
 spec:

--- a/.vonage/catalog-info.yaml
+++ b/.vonage/catalog-info.yaml
@@ -32,5 +32,5 @@ metadata:
 spec:
   type: library
   owner: group:orgdata/vcl
-  system: video-react-native-sdks
+  system: video-react-native-sdk
   lifecycle: production

--- a/.vonage/catalog-info.yaml
+++ b/.vonage/catalog-info.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     vonage.com/jira-id: VIDCS
 spec:
-  type: service
+  type: library
   owner: group:orgdata/vcl
   domain: video-api
 

--- a/.vonage/catalog-info.yaml
+++ b/.vonage/catalog-info.yaml
@@ -1,0 +1,36 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: video-react-native-sdk
+  title: Video React Native SDK
+  description: Video API React Native Client SDK
+  links:
+    - url: https://confluence.vonage.com/display/VIDCLIENT/Client+SDKs
+      title: Confluence Documentation
+      icon: help
+    - url: mailto:video.clients@vonage.com
+      title: Email
+      icon: user
+    - url: https://vonage.enterprise.slack.com/archives/CCY5ZBC6T
+      title: Slack
+      icon: dashboard
+  annotations:
+    vonage.com/jira-id: VIDCS
+spec:
+  type: service
+  owner: group:orgdata/vcl
+  domain: video-api
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: video-react-native-sdk
+  description: OpenTok React Native - a library for OpenTok iOS and Android SDKs
+  annotations:
+    github.com/project-slug: opentok/opentok-react-native
+spec:
+  type: library
+  owner: group:orgdata/vcl
+  system: video-react-native-sdks
+  lifecycle: production

--- a/.vonage/catalog-info.yaml
+++ b/.vonage/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
   name: video-react-native-sdks
-  title: Video React Native SDK
+  title: Video React Native SDKs
   description: Video API React Native Client SDK
   links:
     - url: https://confluence.vonage.com/display/VIDCLIENT/Client+SDKs

--- a/.vonage/catalog-info.yaml
+++ b/.vonage/catalog-info.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
-  name: video-react-native-sdk
+  name: video-react-native-sdks
   title: Video React Native SDK
   description: Video API React Native Client SDK
   links:
@@ -25,12 +25,12 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: video-react-native-sdk
+  name: video-react-native-sdks
   description: OpenTok React Native - a library for OpenTok iOS and Android SDKs
   annotations:
     github.com/project-slug: opentok/opentok-react-native
 spec:
   type: library
   owner: group:orgdata/vcl
-  system: video-react-native-sdk
+  system: video-react-native-sdks
   lifecycle: production

--- a/.vonage/catalog-info.yaml
+++ b/.vonage/catalog-info.yaml
@@ -15,7 +15,7 @@ metadata:
       title: Slack
       icon: dashboard
   annotations:
-    vonage.com/jira-id: VIDCS
+    vonage.com/jira-id: VPF
 spec:
   type: library
   owner: group:orgdata/vcl


### PR DESCRIPTION
### What is this PR doing?

Adding file .vonage/catalog-info.yaml part of the Service Catalog Rollout. See ticket https://jira.vonage.com/browse/VIDCS-4016 for more context.

### What are the relevant tickets?

 [VIDCS-4016](https://jira.vonage.com/browse/VIDCS-4016)

### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)

NA