### PR TITLE
fix: [VIDECO-11487] Clear publishers stream as well if session is subscribeToSelf is enabled

### DIFF
--- a/src/helpers/OTSessionHelper.js
+++ b/src/helpers/OTSessionHelper.js
@@ -42,6 +42,7 @@ const removeStream = (sessionId, streamId) => {
 
 const clearStreams = (sessionId) => {
   streams[sessionId] = [];
+  publisherStreams[sessionId] = undefined;
 };
 
 const getStreams = (sessionId) => streams[sessionId] || [];


### PR DESCRIPTION
This pull request makes a minor adjustment to the `clearStreams` function in `OTSessionHelper.js` to ensure that both `streams` and `publisherStreams` for a given session are reset properly. This helps prevent stale publisher stream data from persisting after clearing streams.

* [`src/helpers/OTSessionHelper.js`](diffhunk://#diff-e388f528300392ad1d21058f7f67f1fbe30f501be900c4442f9738f5e8609ec4R45): Updated `clearStreams` to also reset the `publisherStreams` entry for the specified `sessionId`.

### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
