### PR TITLE
fix: [VIDECO-11495] empty subscriber screens appeared after stop/start publishing

### DIFF
--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -11,6 +11,7 @@ import {
   removeEventListener,
   dispatchEvent,
   isConnected,
+  getPublisherStream,
 } from './helpers/OTSessionHelper';
 import { sanitizeProperties } from './helpers/OTPublisherHelper';
 import OTContext from './contexts/OTContext';
@@ -133,6 +134,16 @@ export default class OTPublisher extends React.Component {
 
   componentWillUnmount() {
     OT.unpublish(this.context.sessionId, this.state.publisherId);
+    const publiherStreamId = getPublisherStream(this.context.sessionId);
+    if (publiherStreamId) {
+      const event = {
+        streamId: publiherStreamId,
+        nativeEvent: {
+          streamId: publiherStreamId,
+        },
+      };
+      this.onStreamDestroyed(event);
+    }
     removeEventListener(
       this.context.sessionId,
       'sessionConnected',
@@ -140,10 +151,15 @@ export default class OTPublisher extends React.Component {
     );
   }
 
-  getPrePermissionViewStyle = (props) => ({
+  getPrePermissionViewStyle = () => ({
     backgroundColor: '#000',
     ...this.props.style,
   });
+
+  onStreamDestroyed = (event) => {
+    dispatchEvent(this.context.sessionId, 'publisherStreamDestroyed', event);
+    this.props.eventHandlers?.streamDestroyed?.(event.nativeEvent);
+  };
 
   render() {
     return this.state.permissionsGranted && this.state.componentMounted ? (
@@ -161,14 +177,7 @@ export default class OTPublisher extends React.Component {
           );
           this.props.eventHandlers?.streamCreated?.(event.nativeEvent);
         }}
-        onStreamDestroyed={(event) => {
-          dispatchEvent(
-            this.context.sessionId,
-            'publisherStreamDestroyed',
-            event
-          );
-          this.props.eventHandlers?.streamDestroyed?.(event.nativeEvent);
-        }}
+        onStreamDestroyed={this.onStreamDestroyed}
         onAudioLevel={(event) => {
           this.props.eventHandlers?.audioLevel?.(event.nativeEvent);
         }}

--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -134,12 +134,12 @@ export default class OTPublisher extends React.Component {
 
   componentWillUnmount() {
     OT.unpublish(this.context.sessionId, this.state.publisherId);
-    const publiherStreamId = getPublisherStream(this.context.sessionId);
-    if (publiherStreamId) {
+    const publisherStreamId = getPublisherStream(this.context.sessionId);
+    if (publisherStreamId) {
       const event = {
-        streamId: publiherStreamId,
+        streamId: publisherStreamId,
         nativeEvent: {
-          streamId: publiherStreamId,
+          streamId: publisherStreamId,
         },
       };
       this.onStreamDestroyed(event);

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -52,6 +52,7 @@ export default class OTSubscriber extends Component {
       this.publisherStreamCreatedHandler
     );
     addEventListener(
+      this.context.sessionId,
       'publisherStreamDestroyed',
       this.publisherStreamDestroyedHandler
     );

--- a/src/helpers/OTSessionHelper.js
+++ b/src/helpers/OTSessionHelper.js
@@ -45,7 +45,7 @@ const clearStreams = (sessionId) => {
   clearPublisherStream(sessionId);
 };
 
-const clearPublsherStream = (sessionId) => {
+const clearPublisherStream = (sessionId) => {
   publisherStreams[sessionId] = undefined;
 };
 

--- a/src/helpers/OTSessionHelper.js
+++ b/src/helpers/OTSessionHelper.js
@@ -42,6 +42,10 @@ const removeStream = (sessionId, streamId) => {
 
 const clearStreams = (sessionId) => {
   streams[sessionId] = [];
+  clearPublsherStream(sessionId);
+};
+
+const clearPublsherStream = (sessionId) => {
   publisherStreams[sessionId] = undefined;
 };
 

--- a/src/helpers/OTSessionHelper.js
+++ b/src/helpers/OTSessionHelper.js
@@ -42,7 +42,7 @@ const removeStream = (sessionId, streamId) => {
 
 const clearStreams = (sessionId) => {
   streams[sessionId] = [];
-  clearPublsherStream(sessionId);
+  clearPublisherStream(sessionId);
 };
 
 const clearPublsherStream = (sessionId) => {


### PR DESCRIPTION
This pull request primarily improves the publisher stream cleanup and event handling logic in the OpenTok React components. The main focus is on ensuring that publisher stream destruction is handled more robustly, especially during component unmount, and that event handlers are consistently managed. Key changes include refactoring stream destruction logic, improving event dispatching, and cleaning up publisher stream state.

**Publisher stream cleanup and event dispatching:**

- In `OTPublisher`, during `componentWillUnmount`, the code now retrieves the publisher stream ID and explicitly triggers the `onStreamDestroyed` handler if a stream exists, ensuring that cleanup and event notification occur reliably. (`src/OTPublisher.js`, [src/OTPublisher.jsR137-R163](diffhunk://#diff-25feee9927a2fe35579b19c4854d6ede42842177158be4099a4e2c9a835f00aaR137-R163))
- The `onStreamDestroyed` logic has been refactored into a dedicated method, which both dispatches the event and calls any provided event handler, improving code reuse and maintainability. (`src/OTPublisher.js`, [[1]](diffhunk://#diff-25feee9927a2fe35579b19c4854d6ede42842177158be4099a4e2c9a835f00aaR137-R163) [[2]](diffhunk://#diff-25feee9927a2fe35579b19c4854d6ede42842177158be4099a4e2c9a835f00aaL164-R180)
- The `onStreamDestroyed` prop for the publisher component is now set to use the new method, further centralizing the destruction logic. (`src/OTPublisher.js`, [src/OTPublisher.jsL164-R180](diffhunk://#diff-25feee9927a2fe35579b19c4854d6ede42842177158be4099a4e2c9a835f00aaL164-R180))

**Helper function improvements:**

- Added `getPublisherStream` and `clearPublsherStream` helper functions to better manage publisher stream state, and ensured that publisher stream state is cleared when all streams are cleared. (`src/helpers/OTSessionHelper.js`, [[1]](diffhunk://#diff-25feee9927a2fe35579b19c4854d6ede42842177158be4099a4e2c9a835f00aaR14) [[2]](diffhunk://#diff-e388f528300392ad1d21058f7f67f1fbe30f501be900c4442f9738f5e8609ec4R45-R48)

**Subscriber event handling:**

- In `OTSubscriber`, the event listener for `publisherStreamDestroyed` now correctly includes the session ID, ensuring proper event subscription. (`src/OTSubscriber.js`, [src/OTSubscriber.jsR55](diffhunk://#diff-627193fbdb1bd885254c05a83d501ea48a1d05cccece0a9397c242245c755928R55))
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
