### PR TITLE
fix: [VIDECO-11489] Subscriber Screen is empty on Android

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
@@ -69,11 +69,37 @@ class OTRNSubscriber : FrameLayout, SubscriberListener,
         }
     }
 
+    private fun findStream(streamId: String): Stream? {
+        // Check subscriberStreams (remote streams)
+        var stream = sharedState.getSubscriberStreams().get(streamId)
+        if (stream != null) return stream
+        
+        // Check publisher streams (your own published streams)
+        val publishers = sharedState.getPublishers()
+        for (publisher in publishers.values) {
+            if (publisher.stream?.streamId == streamId) {
+                return publisher.stream
+            }
+        }
+        return null
+    }
+
     override fun onAttachedToWindow() {
-        session = sharedState.getSessions().get(sessionId)
-        stream = sharedState.getSubscriberStreams().get(streamId)
         super.onAttachedToWindow()
-        subscribeToStream(session ?: return, stream ?: return)
+        
+        val safeSessionId = sessionId
+        val safeStreamId = streamId
+        
+        if (safeSessionId == null || safeStreamId == null) {
+            return
+        }
+        
+        session = sharedState.getSessions().get(safeSessionId)
+        stream = findStream(safeStreamId)
+
+        if (session != null && stream != null) {
+            subscribeToStream(session!!, stream!!)
+        }
     }
 
     private fun configureComponent() {


### PR DESCRIPTION
This pull request improves the robustness of stream lookup and subscription logic in the `OTRNSubscriber` class. The main change is the introduction of a dedicated method to find a stream by its ID, searching both subscriber and publisher streams, and updating the logic in `onAttachedToWindow` to use this method with additional null checks.

Stream lookup and subscription improvements:

* Added a new `findStream` method to search for a stream by ID in both subscriber streams and publisher streams, making the lookup more comprehensive and reliable.
* Updated the `onAttachedToWindow` method to use the new `findStream` method, added null checks for `sessionId` and `streamId`, and ensured that subscription only occurs when both session and stream are found.
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
