### PR TITLE
VIDECO-11517

### DIFF
--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -116,11 +116,14 @@ export default class OTPublisher extends React.Component {
         .catch((error) => {
           // this.otrnEventHandler(error);
         });
-    } else if (this.context && isConnected(this.context.sessionId)) {
-      setTimeout(
-        () => OT.publish(this.context.sessionId, this.state.publisherId),
-        100
-      );
+    } else {
+      // Context and publisherId might not be available immediately
+      // So we delay the publish call slightly
+      setTimeout(() => {
+        if (this.context && isConnected(this.context.sessionId)) {
+          OT.publish(this.context.sessionId, this.state.publisherId);
+        }
+      }, 100);
     }
   };
 


### PR DESCRIPTION
This pull request refines the publishing logic in the `OTPublisher` component to make it more robust when context or publisher ID may not be immediately available. The main change is adding a safety check before attempting to publish, preventing potential errors if the required data is not yet set.

**Improvements to publishing logic:**

* Added a conditional check inside the `setTimeout` callback to ensure both `this.context` and a connected session ID are available before calling `OT.publish`, making the publishing process more reliable when values may be set asynchronously.
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
