### PR TITLE
fix: moved cleanup to a delegate methods

### DIFF
--- a/ios/OTRNPublisherComponentView.swift
+++ b/ios/OTRNPublisherComponentView.swift
@@ -409,8 +409,8 @@ import React
             publisher.audioLevelDelegate = nil
             publisher.networkStatsDelegate = nil
             publisher.rtcStatsReportDelegate = nil
-            OTRN.sharedState.publishers[publisherId] = nil
-            OTRN.sharedState.isPublishing[publisherId] = nil
+            OTRN.sharedState.publishers.removeValue(forKey: publisherId)
+            OTRN.sharedState.isPublishing.removeValue(forKey: publisherId)
             self.publisherId = ""
             self.sessionId = ""
             self.currentSession = nil
@@ -480,6 +480,7 @@ private class PublisherDelegateHandler: NSObject, OTPublisherKitDelegate {
             )
             streamInfo["publisherId"] = publisherId
             OTRN.sharedState.publishers[publisherId] = nil
+            OTRN.sharedState.publishers.removeValue(forKey: publisherId)
             impl?.strictUIViewContainer?.handleStreamDestroyed(streamInfo)
         }
     }

--- a/ios/OpentokReactNative.swift
+++ b/ios/OpentokReactNative.swift
@@ -232,7 +232,6 @@ import React
         }
 
         session.unpublish(publisher, error: &error)
-        OTRN.sharedState.publishers.removeValue(forKey: publisherId)
     }
 
     @objc public func removeSubscriber(_ sessionId: String, streamId: String) {
@@ -247,7 +246,6 @@ import React
         }
 
         session.unsubscribe(subscriber, error: &error)
-        OTRN.sharedState.subscribers.removeValue(forKey: streamId)
     }
 
     @objc public func forceMuteAll(
@@ -488,6 +486,7 @@ private class SessionDelegateHandler: NSObject, OTSessionDelegate {
         let streamInfo: [String: Any] = EventUtils.prepareJSStreamEventData(
             stream)
         OTRN.sharedState.subscriberStreams.removeValue(forKey: stream.streamId)
+        OTRN.sharedState.subscribers.removeValue(forKey: stream.streamId)
         impl?.ot?.emit(onStreamDestroyed: streamInfo)
     }
 


### PR DESCRIPTION
This pull request focuses on improving memory management and state cleanup for publisher and subscriber objects in the iOS OpenTok React Native integration. The main changes ensure that publishers and subscribers are properly removed from shared state dictionaries, reducing the risk of memory leaks or stale references.

**State cleanup improvements:**

* Replaced direct assignment to `nil` with `removeValue(forKey:)` when removing publishers and publishing status from `OTRN.sharedState` in `OTRNPublisherComponentView.swift`, ensuring dictionary entries are properly deleted.
* Added an explicit call to `removeValue(forKey:)` for publishers in the publisher delegate's `streamDestroyed` handler to guarantee publisher cleanup.

**Subscriber management enhancements:**

* Added removal of subscriber objects from `OTRN.sharedState.subscribers` when a stream is destroyed in `OpentokReactNative.swift`, ensuring subscribers are cleaned up along with their streams.

**Redundant code removal:**

* Removed unnecessary calls to `removeValue(forKey:)` for publishers and subscribers in `OpentokReactNative.swift`, as these are now handled more appropriately elsewhere in the code. [[1]](diffhunk://#diff-9ce1922379a17cf6a5ed1a3337ddf0adf039a8273c1563a484c67829258bf691L235) [[2]](diffhunk://#diff-9ce1922379a17cf6a5ed1a3337ddf0adf039a8273c1563a484c67829258bf691L250)
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
