### PR TITLE
VIDCS-4361 RN meet support 

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -177,6 +177,12 @@ declare module 'opentok-react-native' {
 
   interface OTSessionSessionOptions {
     /**
+     * Custom API URL to use instead of the default https://api.opentok.com.
+     * This is useful for testing or using a custom OpenTok server.
+     */
+    apiUrl?: string;
+
+    /**
      * default is false
      */
     connectionEventsSuppressed?: boolean;

--- a/README.md
+++ b/README.md
@@ -304,45 +304,6 @@ allprojects {
 }
 ```
 
-## Custom API URL Configuration
-
-By default, the OpenTok React Native SDK connects to the OpenTok API at `https://api.opentok.com`. You can override this to use a custom API URL by passing the `apiUrl` option to the `OTSession` component. This is useful for testing environments or when using a custom OpenTok server deployment.
-
-### Usage Example
-
-```javascript
-import { OTSession, OTPublisher, OTSubscriber } from 'opentok-react-native';
-
-const sessionOptions = {
-  apiUrl: 'https://your-custom-api-url.com'
-};
-
-<OTSession 
-  apiKey={apiKey} 
-  sessionId={sessionId} 
-  token={token}
-  options={sessionOptions}
->
-  <OTPublisher />
-  <OTSubscriber />
-</OTSession>
-```
-
-### Additional Session Options
-
-The `options` prop also supports other configuration options:
-
-- `connectionEventsSuppressed` (boolean): Whether to suppress connection events
-- `proxyUrl` (string): EU proxy server URL
-- `ipWhitelist` (boolean): Enable IP whitelist feature
-- `enableStereoOutput` (boolean): Enable stereo audio output
-- `enableSinglePeerConnection` (boolean): Use single peer connection mode
-- `sessionMigration` (boolean): Enable session migration
-- `iceConfig` (object): Configure custom TURN servers
-- Android only: `androidOnTop`, `androidZOrder`, `useTextureViews`
-
-For more details, see the [official documentation](https://tokbox.com/developer/sdks/react-native/reference/OTSession.html).
-
 ## Docs
 
 See the [docs](https://tokbox.com/developer/sdks/react-native/reference).

--- a/README.md
+++ b/README.md
@@ -304,6 +304,45 @@ allprojects {
 }
 ```
 
+## Custom API URL Configuration
+
+By default, the OpenTok React Native SDK connects to the OpenTok API at `https://api.opentok.com`. You can override this to use a custom API URL by passing the `apiUrl` option to the `OTSession` component. This is useful for testing environments or when using a custom OpenTok server deployment.
+
+### Usage Example
+
+```javascript
+import { OTSession, OTPublisher, OTSubscriber } from 'opentok-react-native';
+
+const sessionOptions = {
+  apiUrl: 'https://your-custom-api-url.com'
+};
+
+<OTSession 
+  apiKey={apiKey} 
+  sessionId={sessionId} 
+  token={token}
+  options={sessionOptions}
+>
+  <OTPublisher />
+  <OTSubscriber />
+</OTSession>
+```
+
+### Additional Session Options
+
+The `options` prop also supports other configuration options:
+
+- `connectionEventsSuppressed` (boolean): Whether to suppress connection events
+- `proxyUrl` (string): EU proxy server URL
+- `ipWhitelist` (boolean): Enable IP whitelist feature
+- `enableStereoOutput` (boolean): Enable stereo audio output
+- `enableSinglePeerConnection` (boolean): Use single peer connection mode
+- `sessionMigration` (boolean): Enable session migration
+- `iceConfig` (object): Configure custom TURN servers
+- Android only: `androidOnTop`, `androidZOrder`, `useTextureViews`
+
+For more details, see the [official documentation](https://tokbox.com/developer/sdks/react-native/reference/OTSession.html).
+
 ## Docs
 
 See the [docs](https://tokbox.com/developer/sdks/react-native/reference).

--- a/android/src/main/java/com/opentokreactnative/OpentokReactNativeModule.java
+++ b/android/src/main/java/com/opentokreactnative/OpentokReactNativeModule.java
@@ -72,6 +72,7 @@ public class OpentokReactNativeModule extends NativeOpentokSpec implements
         final IncludeServers includeServers = Utils.sanitizeIncludeServer(options.getString("includeServers"));
         final TransportPolicy transportPolicy = Utils.sanitizeTransportPolicy(options.getString("transportPolicy"));
         final String proxyUrl = options.getString("proxyUrl");
+        final String apiUrl = options.getString("apiUrl");
         final String androidOnTop = options.getString("androidOnTop");
         final String androidZOrder = options.getString("androidZOrder");
         final boolean singlePeerConnection = options.getBoolean("enableSinglePeerConnection");
@@ -79,7 +80,7 @@ public class OpentokReactNativeModule extends NativeOpentokSpec implements
         ConcurrentHashMap<String, String> androidOnTopMap = sharedState.getAndroidOnTopMap();
         ConcurrentHashMap<String, String> androidZOrderMap = sharedState.getAndroidZOrderMap();
 
-        Session session = new Session.Builder(context, apiKey, sessionId)
+        Session.Builder sessionBuilder = new Session.Builder(context, apiKey, sessionId)
             .sessionOptions(new Session.SessionOptions() {
                 @Override
                 public boolean useTextureViews() {
@@ -92,8 +93,18 @@ public class OpentokReactNativeModule extends NativeOpentokSpec implements
             .setIpWhitelist(ipWhitelist)
             .setProxyUrl(proxyUrl)
             .setSinglePeerConnection(singlePeerConnection)
-            .setSessionMigration(sessionMigration)
-            .build();
+            .setSessionMigration(sessionMigration);
+
+        // Set custom API URL if provided
+        if (apiUrl != null && !apiUrl.isEmpty()) {
+            try {
+                sessionBuilder.setApiUrl(new java.net.URL(apiUrl));
+            } catch (java.net.MalformedURLException e) {
+                android.util.Log.e(NAME, "Invalid API URL: " + apiUrl, e);
+            }
+        }
+
+        Session session = sessionBuilder.build();
 
         sharedState.getSessions().put(sessionId, session);
 

--- a/ios/OpentokReactNative.mm
+++ b/ios/OpentokReactNative.mm
@@ -61,6 +61,7 @@ RCT_EXPORT_MODULE()
         optionsDict[@"ipWhitelist"] = @(options.ipWhitelist().value());
     }
     optionsDict[@"proxyUrl"] = options.proxyUrl();
+    optionsDict[@"apiUrl"] = options.apiUrl();
 
     if (options.iceConfig().has_value()) {
         NSMutableDictionary *iceConfigDict = [NSMutableDictionary dictionary];

--- a/ios/OpentokReactNative.swift
+++ b/ios/OpentokReactNative.swift
@@ -52,6 +52,16 @@ import React
             OTRN.sharedState.sessionDelegateHandlers.removeValue(forKey: sessionId)
             return
         }
+        
+        // Set custom API URL if provided
+        let apiUrlString = Utils.sanitizeStringProperty(sessionOptions["apiUrl"] as Any)
+        if !apiUrlString.isEmpty, let apiUrl = URL(string: apiUrlString) {
+            // Use the private setApiRootURL method available in OTSession
+            if session.responds(to: Selector(("setApiRootURL:"))) {
+                session.perform(Selector(("setApiRootURL:")), with: apiUrl)
+            }
+        }
+        
         OTRN.sharedState.sessions.updateValue(session, forKey: sessionId)
     }
 

--- a/src/NativeOpentok.ts
+++ b/src/NativeOpentok.ts
@@ -40,6 +40,7 @@ export type MuteForcedEvent = {
 
 export type SessionOptions = {
   androidZOrder?: string;
+  apiUrl?: string;
   connectionEventsSuppressed?: boolean;
   enableStereoOutput?: boolean;
   enableSinglePeerConnection?: boolean;

--- a/src/helpers/OTSessionHelper.js
+++ b/src/helpers/OTSessionHelper.js
@@ -134,6 +134,7 @@ const sanitizeSessionOptions = (options) => {
 
   if (platform === 'android') {
     sessionOptions = {
+      apiUrl: '',
       connectionEventsSuppressed: false,
       ipWhitelist: false,
       iceConfig: {},
@@ -147,6 +148,7 @@ const sanitizeSessionOptions = (options) => {
     };
   } else {
     sessionOptions = {
+      apiUrl: '',
       connectionEventsSuppressed: false,
       ipWhitelist: false,
       iceConfig: {},
@@ -163,6 +165,7 @@ const sanitizeSessionOptions = (options) => {
 
   const validSessionOptions = {
     ios: {
+      apiUrl: 'string',
       connectionEventsSuppressed: 'boolean',
       ipWhitelist: 'boolean',
       iceConfig: 'object',
@@ -172,6 +175,7 @@ const sanitizeSessionOptions = (options) => {
       sessionMigration: 'boolean',
     },
     android: {
+      apiUrl: 'string',
       connectionEventsSuppressed: 'boolean',
       useTextureViews: 'boolean',
       androidOnTop: 'string',


### PR DESCRIPTION
Added setApiURL parameter to the session builder so it can use custom servers, instead of the default production one.

This is necessary for enabling meet support in the test app as it uses DEV endpoint

To test this please refer to https://github.com/opentok/React-native-TestApp
